### PR TITLE
Add server.json and mcpName for MCP Registry publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ryancardin/noaa-tides-currents-mcp-server",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "MCP server for NOAA CO-OPS Tides and Currents: water levels, tide predictions, currents, meteorology, station metadata, datums, high tide flooding, sea level trends, plus sun and moon calculations",
   "main": "dist/index.js",
   "bin": {
@@ -35,7 +35,7 @@
     "api"
   ],
   "author": "Ryan Cardin",
-  "mcpName": "io.github.ryancardin15/noaa-tides-and-currents-mcp",
+  "mcpName": "io.github.RyanCardin15/noaa-tides-and-currents-mcp",
   "repository": {
     "type": "git",
     "url": "https://github.com/RyanCardin15/NOAA-Tides-And-Currents-MCP.git"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "api"
   ],
   "author": "Ryan Cardin",
+  "mcpName": "io.github.ryancardin15/noaa-tides-and-currents-mcp",
   "repository": {
     "type": "git",
     "url": "https://github.com/RyanCardin15/NOAA-Tides-And-Currents-MCP.git"

--- a/server.json
+++ b/server.json
@@ -1,18 +1,18 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
-  "name": "io.github.ryancardin15/noaa-tides-and-currents-mcp",
-  "description": "NOAA CO-OPS tides and currents: water levels, tide predictions, currents, meteorology, station metadata, datums, high tide flooding, sea level trends, sun and moon calculations",
+  "name": "io.github.RyanCardin15/noaa-tides-and-currents-mcp",
+  "description": "NOAA tides and currents: water levels, tide predictions, currents, met data, flooding, sun and moon",
   "repository": {
     "url": "https://github.com/RyanCardin15/NOAA-Tides-And-Currents-MCP",
     "source": "github"
   },
-  "version": "2.0.0",
+  "version": "2.0.1",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@ryancardin/noaa-tides-currents-mcp-server",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "transport": {
         "type": "stdio"
       }

--- a/server.json
+++ b/server.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+  "name": "io.github.ryancardin15/noaa-tides-and-currents-mcp",
+  "description": "NOAA CO-OPS tides and currents: water levels, tide predictions, currents, meteorology, station metadata, datums, high tide flooding, sea level trends, sun and moon calculations",
+  "repository": {
+    "url": "https://github.com/RyanCardin15/NOAA-Tides-And-Currents-MCP",
+    "source": "github"
+  },
+  "version": "2.0.0",
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "@ryancardin/noaa-tides-currents-mcp-server",
+      "version": "2.0.0",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds the official MCP Registry metadata (server.json + mcpName in package.json) needed to publish to registry.modelcontextprotocol.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)