### PR TITLE
Add Codex developer flow automation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,35 @@
+name: Bug report
+description: A defect or regression in the NOAA MCP server.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: textarea
+    id: observed
+    attributes:
+      label: Observed Behavior
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction Steps
+      placeholder: |
+        1. 
+        2. 
+        3. 
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Logs, MCP requests, responses, NOAA examples, or failing test output.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/codex_plan.yml
+++ b/.github/ISSUE_TEMPLATE/codex_plan.yml
@@ -1,0 +1,60 @@
+name: Codex plan
+description: A Codex-generated plan that needs owner approval before implementation.
+title: "[Codex Plan]: "
+labels:
+  - codex-plan
+  - needs-owner-approval
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Codex builder jobs may only implement this after the owner applies the `codex-approved` label.
+  - type: input
+    id: area
+    attributes:
+      label: Area
+      description: Tool group, service layer, transport, docs, package metadata, or registry surface affected.
+      placeholder: water tools, DPAPI, HTTP transport, README, server.json
+    validations:
+      required: true
+  - type: textarea
+    id: opportunity
+    attributes:
+      label: Opportunity
+      description: What Codex found and why it matters.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed Change
+      description: The smallest coherent implementation Codex recommends.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: Concrete checks the PR must satisfy.
+      placeholder: |
+        - ...
+        - ...
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Links, logs, failing examples, tool outputs, or test output that motivated the plan.
+    validations:
+      required: false
+  - type: dropdown
+    id: risk
+    attributes:
+      label: Risk
+      options:
+        - Low
+        - Medium
+        - High
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+## Summary
+
+- 
+
+## Verification
+
+- [ ] `npm run build`
+- [ ] `npm test`
+- [ ] `npm run test:live`, when NOAA/API behavior changes
+- [ ] Package metadata checked, when versioning or registry files change
+
+## MCP Behavior
+
+List any added, removed, renamed, or behaviorally changed tools/resources/prompts.
+
+## Risk And Rollback
+
+- Risk:
+- Rollback:
+
+## Codex Notes
+
+- Related plan issue:
+- Owner approval source:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: noaa-mcp-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Build and test
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test
+
+      - name: Validate package metadata
+        run: |
+          node -e '
+            const fs = require("fs");
+            const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+            const server = JSON.parse(fs.readFileSync("server.json", "utf8"));
+            if (pkg.version !== server.version) {
+              throw new Error(`package.json version ${pkg.version} does not match server.json version ${server.version}`);
+            }
+            const npmPackage = server.packages?.find((entry) => entry.registryType === "npm");
+            if (!npmPackage) {
+              throw new Error("server.json must include an npm package entry");
+            }
+            if (npmPackage.identifier !== pkg.name) {
+              throw new Error(`server.json package ${npmPackage.identifier} does not match package.json name ${pkg.name}`);
+            }
+            if (npmPackage.version !== pkg.version) {
+              throw new Error(`server.json package version ${npmPackage.version} does not match package.json version ${pkg.version}`);
+            }
+          '

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,42 @@
+name: Publish To npm
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: Publish package
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test
+
+      - name: Publish
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/docs/dev-flow/CODEX_AUTOMATIONS.md
+++ b/docs/dev-flow/CODEX_AUTOMATIONS.md
@@ -57,6 +57,11 @@ Issue quality bar:
 
 Purpose: implement one approved GitHub issue end-to-end.
 
+Prerequisite: `.github/workflows/ci.yml` must already exist on the current
+`main` checkout. If the bootstrap developer-flow PR has not been merged yet,
+the builder must stop and send an iMessage explaining that approved
+implementation is blocked until CI is present on `main`.
+
 Run behavior:
 
 1. Find the highest-value open issue labeled `codex-approved` and `codex-plan`.

--- a/docs/dev-flow/CODEX_AUTOMATIONS.md
+++ b/docs/dev-flow/CODEX_AUTOMATIONS.md
@@ -1,0 +1,81 @@
+# Codex Automations For NOAA MCP
+
+Codex owns scheduled package exploration and implementation. GitHub owns durable review records and CI status. The owner approves work through GitHub issue labels.
+
+GitHub repository: `RyanCardin15/Perigee-Tides`.
+
+## Notification Channel
+
+Codex sends owner-facing updates through the local Mac Messages app by running:
+
+```bash
+scripts/codex-imessage.sh "message text"
+```
+
+The default recipient is `832-212-1341`. Override with `CODEX_IMESSAGE_TO` if needed.
+
+Use iMessage only for high-signal outcomes:
+
+- A new high-value plan was created.
+- An approved implementation PR is ready.
+- A scheduled run is blocked and needs owner action.
+- Live smoke testing finds an actionable regression.
+
+## MCP Scout
+
+Purpose: inspect the MCP package and create owner-reviewable GitHub issues.
+
+Run behavior:
+
+1. Confirm the working tree is clean. If not, avoid edits and continue read-only.
+2. Review `README.md`, `CLAUDE.md`, recent commits, open issues, open PRs, `server.json`, and `smithery.yaml`.
+3. Run cheap health checks when useful: `npm run build`, `npm test`.
+4. Use `npm run test:live` when a plan depends on live NOAA behavior.
+5. Look for concrete improvements in:
+   - tool schemas and descriptions
+   - NOAA edge-case handling
+   - output formatting
+   - resources and prompts
+   - HTTP transport behavior
+   - package metadata and registry docs
+   - README accuracy
+   - test coverage
+6. Create at most three GitHub issues for the best plans.
+7. Label plans with `codex-plan` and `needs-owner-approval`.
+8. Do not implement code.
+9. Send one iMessage only if a strong plan was created or the run is blocked.
+
+Issue quality bar:
+
+- State the affected tool group, service, or package surface.
+- Explain why the change matters.
+- Propose the smallest coherent implementation.
+- Include acceptance criteria.
+- Include logs, tool examples, or test output when available.
+
+## MCP Approved Builder
+
+Purpose: implement one approved GitHub issue end-to-end.
+
+Run behavior:
+
+1. Find the highest-value open issue labeled `codex-approved` and `codex-plan`.
+2. If none exists, stop without messaging.
+3. Confirm the issue is not already linked to an open PR.
+4. Create a feature branch.
+5. Implement the smallest coherent change satisfying the issue acceptance criteria.
+6. Run required checks:
+   - `npm run build`
+   - `npm test`
+   - `npm run test:live` when tool/API behavior changes
+7. Open a pull request linked to the issue.
+8. Remove `needs-owner-approval`, add `codex-implemented`.
+9. Send an iMessage with the PR number, check status, and any review notes.
+
+Hard limits:
+
+- Do not merge PRs.
+- Do not publish npm packages.
+- Do not create releases.
+- Do not implement unapproved issues.
+- Preserve unrelated local changes.

--- a/docs/dev-flow/DEVELOPER_FLOW.md
+++ b/docs/dev-flow/DEVELOPER_FLOW.md
@@ -1,0 +1,55 @@
+# NOAA MCP Developer Flow
+
+This repository uses GitHub for review and deterministic checks, and Codex for scheduled package scouting, implementation, live smoke verification, and owner-facing iMessage updates.
+
+## Branching
+
+- `main` is the release branch.
+- Normal work starts from a feature branch.
+- Merge through pull requests only.
+- Prefer squash merge so each PR lands as one coherent change.
+
+## Required Pull Request Checks
+
+Every PR should pass:
+
+- `npm run build`
+- `npm test`
+- `npm run test:live` when NOAA API behavior, tool behavior, transport, or formatting changes.
+
+The GitHub Actions workflow in `.github/workflows/ci.yml` runs build/test and validates package metadata.
+
+## Owner Approval Gate
+
+Codex-generated plans live as GitHub issues with the `codex-plan` label.
+
+Codex builder automations must not implement a plan until the owner applies `codex-approved`.
+
+Recommended lifecycle:
+
+1. Codex scout creates an issue labeled `codex-plan` and `needs-owner-approval`.
+2. Owner reviews the issue.
+3. Owner applies `codex-approved` to approve implementation.
+4. Codex builder creates a feature branch and pull request.
+5. Owner reviews and merges the pull request.
+
+## Labels
+
+- `codex-plan`: a plan produced by Codex.
+- `needs-owner-approval`: waiting for owner review.
+- `codex-approved`: owner approved Codex to implement.
+- `codex-in-progress`: Codex has started implementation.
+- `codex-implemented`: Codex opened a PR.
+- `live-smoke`: live NOAA smoke testing is required.
+
+## Releases
+
+Publishing to npm is intentionally release-driven:
+
+1. Prepare a version bump PR.
+2. Ensure `package.json`, `package-lock.json`, and `server.json` agree.
+3. Merge after CI passes.
+4. Create a GitHub Release.
+5. The npm publish workflow runs from the release event using `NPM_TOKEN`.
+
+After NOAA changes land, sync `src/` into the Perigee web app in a separate Perigee PR.

--- a/scripts/codex-imessage.sh
+++ b/scripts/codex-imessage.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TO="${CODEX_IMESSAGE_TO:-832-212-1341}"
+DRY_RUN=0
+
+if [[ "${1:-}" == "--dry-run" ]]; then
+  DRY_RUN=1
+  shift
+fi
+
+if [[ $# -gt 0 ]]; then
+  MESSAGE="$*"
+else
+  MESSAGE="$(cat)"
+fi
+
+if [[ -z "${MESSAGE// }" ]]; then
+  echo "Usage: scripts/codex-imessage.sh [--dry-run] \"message text\"" >&2
+  exit 2
+fi
+
+if [[ "$DRY_RUN" == "1" ]]; then
+  printf 'Codex iMessage dry run to %s:\n%s\n' "$TO" "$MESSAGE"
+  exit 0
+fi
+
+osascript - "$TO" "$MESSAGE" <<'APPLESCRIPT'
+on run argv
+  set targetPhone to item 1 of argv
+  set targetMessage to item 2 of argv
+  tell application "Messages"
+    set targetService to 1st service whose service type = iMessage
+    set targetBuddy to buddy targetPhone of targetService
+    send targetMessage to targetBuddy
+  end tell
+end run
+APPLESCRIPT


### PR DESCRIPTION
## Summary
- Adds GitHub CI for build, tests, and package metadata validation.
- Adds release-driven npm publish workflow.
- Adds PR and issue templates for Codex plan approval.
- Documents the Codex scout/builder operating model.
- Adds a local Mac iMessage helper for Codex-authored updates.

Closes #5 after owner approval and merge.

## Verification
- `npm run build` passed.
- `npm test` passed: 36 tests.
- YAML templates/workflows parsed successfully.
- `scripts/codex-imessage.sh --dry-run ...` passed without sending.

## Risk And Rollback
- Risk: npm publishing requires `NPM_TOKEN`; release workflow will fail until that repository secret is configured.
- Rollback: revert this PR to remove CI/templates/docs/scripts.

## Codex Notes
- Related plan issue: #5
- Owner approval source: apply `codex-approved` to #5 or approve this PR.