### PR TITLE
Fix NOAA MCP docs and package metadata drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ src/
 ├── format/             # unit labeling, flag legends, markdown/json response shaping
 ├── schemas/            # shared Zod field schemas with nuance-carrying descriptions
 ├── services/           # Data API, Metadata API, DPAPI, moon & sun services
-├── tools/              # 23 tool registrations grouped by domain
+├── tools/              # 25 tool registrations grouped by domain
 ├── resources/          # noaa:// reference resources
 ├── prompts/            # workflow prompt templates
 └── reference/          # curated NOAA reference content

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ryancardin/noaa-tides-currents-mcp-server",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ryancardin/noaa-tides-currents-mcp-server",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -38,12 +38,12 @@
   "mcpName": "io.github.RyanCardin15/noaa-tides-and-currents-mcp",
   "repository": {
     "type": "git",
-    "url": "https://github.com/RyanCardin15/NOAA-Tides-And-Currents-MCP.git"
+    "url": "https://github.com/RyanCardin15/Perigee-Tides.git"
   },
   "bugs": {
-    "url": "https://github.com/RyanCardin15/NOAA-Tides-And-Currents-MCP/issues"
+    "url": "https://github.com/RyanCardin15/Perigee-Tides/issues"
   },
-  "homepage": "https://github.com/RyanCardin15/NOAA-Tides-And-Currents-MCP#readme",
+  "homepage": "https://github.com/RyanCardin15/Perigee-Tides#readme",
   "publishConfig": {
     "access": "public"
   },

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.RyanCardin15/noaa-tides-and-currents-mcp",
   "description": "NOAA tides and currents: water levels, tide predictions, currents, met data, flooding, sun and moon",
   "repository": {
-    "url": "https://github.com/RyanCardin15/NOAA-Tides-And-Currents-MCP",
+    "url": "https://github.com/RyanCardin15/Perigee-Tides",
     "source": "github"
   },
   "version": "2.0.1",


### PR DESCRIPTION
## Summary

- Update the README architecture tree to reflect the current 25 registered tools.
- Point package and MCP registry repository metadata at the actual GitHub repository for this checkout.
- Align the package-lock root version with package.json/server.json version 2.0.1.

## Validation

- `npm run build`
- `npm test`
- `git diff --check`
- Metadata consistency check for package/server/lock versions and repository URLs