### PR TITLE
Add fishing data layers and interactive MCP Apps charts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Development Commands
 
-- `npm run build` - Compile TypeScript to `dist/`
+- `npm run build` - Compile TypeScript to `dist/`, typecheck the chart UI (`tsconfig.ui.json`), and bundle the MCP Apps template to `dist/ui/perigee-charts.html` (`scripts/build-ui.mjs`, esbuild)
 - `npm test` - Run vitest unit tests (validation, formatting, cache, astronomy)
 - `npm run test:live` - End-to-end smoke test: spins up the built server over stdio and exercises every tool against the live NOAA API (`scripts/smoke-live.mjs`)
 - `npm run inspector` - MCP Inspector against `dist/index.js`
@@ -21,8 +21,9 @@ MCP server built on the official `@modelcontextprotocol/sdk` (`McpServer` + `reg
 
 Layers (dependencies point downward):
 
-- `src/tools/*` — 25 tool registrations grouped by domain (water, currents, met, stations, station-metadata, derived, astronomy, marine-forecast, reference). Each tool: Zod input schema with nuance-carrying `.describe()` texts, read-only annotations, markdown+json `response_format`, `structuredContent` attached, errors returned via `respondError` (never thrown to the protocol layer).
-- `src/services/*` — one module per NOAA API surface (`data-api.ts`, `metadata-api.ts`, `dpapi.ts`) plus local `moon-phase-service.ts` / `sun-service.ts` (suncalc).
+- `src/tools/*` — 30 tool registrations grouped by domain (water, currents, met, stations, station-metadata, derived, astronomy, solunar, buoys, marine-forecast, marine-conditions, reference). Each tool: Zod input schema with nuance-carrying `.describe()` texts, read-only annotations, markdown+json `response_format`, `structuredContent` attached, errors returned via `respondError` (never thrown to the protocol layer).
+- `src/services/*` — one module per API surface (`data-api.ts`, `metadata-api.ts`, `dpapi.ts`, `nws-api.ts`, `ndbc.ts`, `open-meteo.ts`) plus local `moon-phase-service.ts` / `sun-service.ts` / `solunar-service.ts` (suncalc).
+- `src/ui/app-resource.ts` + `ui/src/*` — MCP Apps (SEP-1865) interactive charts. One self-contained template (`ui://perigee/charts.html`, mimeType `text/html;profile=mcp-app`) dispatches on `structuredContent.viz.kind` (`tide_curve`, `solunar`, `buoy_obs`, `marine_forecast`). Tools opt in via `registerAppTool` + `_meta.ui.resourceUri`. The template declares no CSP, so it runs in the zero-network sandbox — all chart code is hand-rolled SVG inlined by esbuild; data arrives only via `ui/notifications/tool-result`. Hosts without Apps support ignore `_meta.ui` and get markdown/JSON — keep that fallback complete.
 - `src/client/http.ts` — shared axios layer: 30s timeout, 2 retries with backoff on network/5xx/429, and error mapping that appends actionable hints. The three NOAA APIs fail differently: the Data API and DPAPI return HTTP 200 or 4xx with `{"error":{"message"}}` bodies; the Metadata API returns bare 404s with no body.
 - `src/client/cache.ts` — in-memory TTL cache (station directory 6h, station resources 1h). Nearest-station search is client-side Haversine over the cached directory because MDAPI ignores lat/lon/radius on its list endpoint (verified live).
 - `src/validation/dates.ts` — normalizes ISO dates to NOAA formats, enforces the five legal date-param combinations, and pre-validates per-product maximum request spans (see `MAX_SPAN_DAYS`).
@@ -43,9 +44,12 @@ Do not "simplify" these away; they mirror NOAA API behavior verified against the
 - MDAPI response array keys differ from NOAA's docs (`datums`, `HarmonicConstituents`, `sensors`, `bins`, `notices`, `products`) — `extractList()` parses defensively.
 - DPAPI endpoint paths were verified live (e.g. `/webapi/product/sealvltrends.json`, `/webapi/product.json?name=toptenwaterlevels`, `/webapi/htf/htf_annual.json`). HTF `range` only works together with `year`; the service translates a bare `range` into "last N years".
 - The Data API `application` parameter is set on every call for NOAA traffic attribution.
+- NDBC has no JSON API: `/activestations.xml` (regex-parsed, flat self-closing tags) and `/data/realtime2/{ID}.txt` (two `#` header lines, columns resolved by NAME not position, `MM` = missing, rows NEWEST first, fixed metric units — conversion happens at the tool layer). NDBC IDs are a separate namespace from CO-OPS station IDs.
+- Open-Meteo Marine is MODEL output (not observations), free non-commercial with attribution; `cell_selection=sea` snaps coastal points to ocean cells; error bodies are `{"error":true,"reason":...}`; native units m/°C/km-h (currents display as knots english / cm/s metric per repo convention).
+- Solunar is computed locally: majors = lunar transits found by scanning `SunCalc.getMoonPosition` altitude extrema at 1-min steps (suncalc has no transit function; a calendar day can lack one), minors = moonrise/set. Day boundaries use the IANA zone when given, else a longitude-derived fixed offset.
 
 ## Conventions
 
-- Tool names: `noaa_*` for CO-OPS-backed tools, `nws_*` for NWS Weather API forecasts, `astro_*` for local astronomy.
+- Tool names: `noaa_*` for CO-OPS-backed tools, `nws_*` for NWS Weather API forecasts, `astro_*` for local astronomy (incl. solunar), `ndbc_*` for NDBC buoys, `openmeteo_*` for Open-Meteo marine models.
 - New tools follow the existing pattern: schema in the register call, try/catch returning `respond()`/`respondError()`, units labeled in output, README + reference content updated.
 - Transport stays stdio-first for MCP client integration; the HTTP mode is stateless (fresh server+transport per request).

--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@
 
 Built by [Cardin Labs](https://cardinlabs.com) · Hosted at [Perigee](https://perigee-two.vercel.app)
 
-Water levels · tide predictions · currents · marine weather · station metadata ·
-tidal datums · harmonic constituents · sea level trends & projections ·
-high tide flooding · sun & moon calculations
+Water levels · tide predictions · currents · marine weather · buoy observations ·
+solunar fishing forecasts · barometric bite logic · wave & SST models ·
+station metadata · tidal datums · harmonic constituents · sea level trends &
+projections · high tide flooding · sun & moon calculations ·
+interactive charts (MCP Apps)
 
 </div>
 
@@ -58,69 +60,93 @@ No API key is required — NOAA's CO-OPS APIs are open.
 
 ---
 
-## Tools (25)
+## Tools (30)
 
 ### Observations & Predictions (Data API)
 
-| Tool | What it does |
-|---|---|
-| `noaa_get_water_levels` | Observed water levels: 1-minute, 6-minute, or hourly series, preliminary/verified quality flags decoded |
-| `noaa_get_water_level_summaries` | high_low (HH/H/L/LL daily extremes), daily_mean (Great Lakes), daily_max_min, monthly_mean datum tables |
-| `noaa_get_tide_predictions` | Harmonic tide predictions — `hilo` high/low events (up to 10 years) or interval series |
-| `noaa_get_currents` | Observed current speed/direction by depth bin (ADCP), optional beam diagnostics |
-| `noaa_get_current_predictions` | Predicted currents — `max_slack` flood/ebb/slack events or interval series |
-| `noaa_get_meteorological_data` | Wind, air/water temperature, pressure, air gap (bridge clearance), conductivity, visibility, humidity, salinity |
+| Tool                             | What it does                                                                                                                                    |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `noaa_get_water_levels`          | Observed water levels: 1-minute, 6-minute, or hourly series, preliminary/verified quality flags decoded                                         |
+| `noaa_get_water_level_summaries` | high_low (HH/H/L/LL daily extremes), daily_mean (Great Lakes), daily_max_min, monthly_mean datum tables                                         |
+| `noaa_get_tide_predictions`      | Harmonic tide predictions — `hilo` high/low events (up to 10 years) or interval series. Renders an interactive tide curve in MCP Apps hosts     |
+| `noaa_get_currents`              | Observed current speed/direction by depth bin (ADCP), optional beam diagnostics                                                                 |
+| `noaa_get_current_predictions`   | Predicted currents — `max_slack` flood/ebb/slack events or interval series                                                                      |
+| `noaa_get_meteorological_data`   | Wind, air/water temperature, pressure, air gap (bridge clearance), conductivity, visibility, humidity, salinity                                 |
+| `noaa_get_pressure_trend`        | Barometric trajectory classified into angler-meaningful states (falling rapidly → rising rapidly) with 3h/6h/24h deltas and bite interpretation |
 
 ### Station Discovery & Metadata (Metadata API)
 
-| Tool | What it does |
-|---|---|
-| `noaa_search_stations` | Search the station directory by capability type, name substring, state — paginated |
-| `noaa_find_nearest_stations` | Nearest stations to any lat/lon (great-circle, cached directory), filterable by type |
-| `noaa_get_station_info` | Full station record with expandable sensors, flood levels, benchmarks, bins, deployments... |
-| `noaa_get_station_datums` | Tidal datum elevations (MLLW, MSL, MHHW, NAVD88...), HAT/LAT, historic extremes, current or superseded epoch |
-| `noaa_get_harmonic_constituents` | The M2/S2/K1/... constituents behind a station's predictions (water level or current ellipse form) |
-| `noaa_get_prediction_offsets` | Subordinate-station time/height offsets from their reference stations (tide or current) |
+| Tool                             | What it does                                                                                                 |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `noaa_search_stations`           | Search the station directory by capability type, name substring, state — paginated                           |
+| `noaa_find_nearest_stations`     | Nearest stations to any lat/lon (great-circle, cached directory), filterable by type                         |
+| `noaa_get_station_info`          | Full station record with expandable sensors, flood levels, benchmarks, bins, deployments...                  |
+| `noaa_get_station_datums`        | Tidal datum elevations (MLLW, MSL, MHHW, NAVD88...), HAT/LAT, historic extremes, current or superseded epoch |
+| `noaa_get_harmonic_constituents` | The M2/S2/K1/... constituents behind a station's predictions (water level or current ellipse form)           |
+| `noaa_get_prediction_offsets`    | Subordinate-station time/height offsets from their reference stations (tide or current)                      |
 
 ### Climate & Derived Products (DPAPI)
 
-| Tool | What it does |
-|---|---|
-| `noaa_get_sea_level_trends` | Long-term relative sea level trend with error bars and observation period |
-| `noaa_get_sea_level_rise_projections` | 2022 Interagency SLR scenario projections per decade through 2150 |
-| `noaa_get_extreme_water_levels` | Annual exceedance probability levels (e.g. the "100-year" water level) |
-| `noaa_get_top_ten_water_levels` | Highest water levels ever recorded, with causal events (hurricanes, nor'easters) |
-| `noaa_get_high_tide_flooding` | HTF flood-day counts (daily/monthly/seasonal/annual), outlooks, decadal projections, likelihoods |
+| Tool                                  | What it does                                                                                     |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `noaa_get_sea_level_trends`           | Long-term relative sea level trend with error bars and observation period                        |
+| `noaa_get_sea_level_rise_projections` | 2022 Interagency SLR scenario projections per decade through 2150                                |
+| `noaa_get_extreme_water_levels`       | Annual exceedance probability levels (e.g. the "100-year" water level)                           |
+| `noaa_get_top_ten_water_levels`       | Highest water levels ever recorded, with causal events (hurricanes, nor'easters)                 |
+| `noaa_get_high_tide_flooding`         | HTF flood-day counts (daily/monthly/seasonal/annual), outlooks, decadal projections, likelihoods |
 
 ### Astronomy (computed locally)
 
-| Tool | What it does |
-|---|---|
-| `astro_get_moon_phase` | Phase, illumination, age, distance for a date or range (spring/neap tide context) |
-| `astro_get_next_moon_phase` | Next new/full/quarter moon date(s) |
-| `astro_get_sun_times` | Sunrise/sunset, twilights, golden hour, day length for any location/date |
-| `astro_get_sun_position` | Azimuth/altitude (+ approximate declination/RA) |
-| `astro_get_next_sun_event` | Next occurrence(s) of any sun event |
+| Tool                         | What it does                                                                                                                                            |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `astro_get_moon_phase`       | Phase, illumination, age, distance for a date or range (spring/neap tide context)                                                                       |
+| `astro_get_next_moon_phase`  | Next new/full/quarter moon date(s)                                                                                                                      |
+| `astro_get_sun_times`        | Sunrise/sunset, twilights, golden hour, day length for any location/date                                                                                |
+| `astro_get_sun_position`     | Azimuth/altitude (+ approximate declination/RA)                                                                                                         |
+| `astro_get_next_sun_event`   | Next occurrence(s) of any sun event                                                                                                                     |
+| `astro_get_solunar_forecast` | Solunar bite-time forecast: major/minor feeding windows, 0-100 day rating with factors, half-hourly activity curve. Interactive chart in MCP Apps hosts |
 
-### Wind & Marine Forecasts (NWS Weather API)
+### Buoys (NDBC)
 
-| Tool | What it does |
-|---|---|
-| `nws_get_wind_forecast` | Hourly numeric wind forecast (speed/gust/direction, wave height where gridded) for any US lat/lon, up to ~7 days |
-| `nws_get_marine_forecast` | Official Coastal Waters Forecast narrative for the marine zone covering a lat/lon, incl. Small Craft Advisories |
+| Tool                         | What it does                                                                                                                              |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `ndbc_find_nearest_buoys`    | Nearest active NDBC buoys / C-MAN stations to any lat/lon, with sensor capability flags                                                   |
+| `ndbc_get_buoy_observations` | Realtime buoy obs: wind, wave height/period/direction, water temp, pressure + 3h tendency (PTDY). Interactive dashboard in MCP Apps hosts |
+
+### Wind & Marine Forecasts (NWS Weather API + Open-Meteo)
+
+| Tool                            | What it does                                                                                                                                                 |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `nws_get_wind_forecast`         | Hourly numeric wind forecast (speed/gust/direction, wave height where gridded) for any US lat/lon, up to ~7 days                                             |
+| `nws_get_marine_forecast`       | Official Coastal Waters Forecast narrative for the marine zone covering a lat/lon, incl. Small Craft Advisories                                              |
+| `openmeteo_get_marine_forecast` | Hourly wave/swell/SST/surface-current model forecast for any ocean coordinate worldwide ("virtual buoy"), up to 10 days. Interactive chart in MCP Apps hosts |
 
 ### Reference
 
-| Tool | What it does |
-|---|---|
-| `noaa_get_reference_guide` | Curated NOAA reference: products, datums, units, time zones, intervals, station types, data limits, quality flags, date formats, marine forecasts |
+| Tool                       | What it does                                                                                                                                                       |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `noaa_get_reference_guide` | Curated NOAA reference: products, datums, units, time zones, intervals, station types, data limits, quality flags, date formats, marine forecasts, fishing toolkit |
 
 Every tool supports `response_format: "markdown"` (readable tables with units spelled out — the default) or `"json"` (complete structured payload), and attaches structured content for MCP clients that consume it.
+
+## Interactive Charts (MCP Apps)
+
+Four tools additionally render **interactive visualizations** in hosts that support the official [MCP Apps extension](https://blog.modelcontextprotocol.io/posts/2026-01-26-mcp-apps/) (Claude.ai, Claude Desktop, ChatGPT, VS Code, Goose, Postman...):
+
+| Tool                            | Visualization                                                                                                              |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `noaa_get_tide_predictions`     | Tide curve (cosine-reconstructed from high/low events) with labeled H/L markers, hover crosshair, 24h/3d/all range chips   |
+| `astro_get_solunar_forecast`    | Feeding-activity curve with major/minor period bands, sunrise/sunset markers, day-rating stat tiles, per-day tabs          |
+| `ndbc_get_buoy_observations`    | Multi-panel conditions dashboard (wind+gust, waves, pressure, water/air temp) with shared crosshair and latest-value tiles |
+| `openmeteo_get_marine_forecast` | Wave/swell/period/SST/current forecast panels                                                                              |
+
+The charts are a single self-contained HTML template (`ui://perigee/charts.html`, hand-rolled SVG — no CDN, works in the locked-down zero-network MCP Apps sandbox), light/dark theme aware, with tooltips and time-range filters. Hosts without MCP Apps support simply get the normal markdown/JSON output — nothing is lost.
 
 ## Resources
 
 - `noaa://guide/getting-started` — workflow recipes and common pitfalls
-- `noaa://reference/{topic}` — the ten reference topics above as pinnable resources
+- `noaa://reference/{topic}` — the reference topics above as pinnable resources
+- `ui://perigee/charts.html` — the MCP Apps chart template (hosts fetch this automatically)
 
 ## Prompts
 
@@ -136,7 +162,7 @@ Every tool supports `response_format: "markdown"` (readable tables with units sp
 These are the things that make NOAA's API tricky — this server encodes them:
 
 - **Datums matter.** Heights are meaningless without a vertical reference. MLLW (chart datum) is the default; stations differ in which datums they support (Great Lakes use IGLD/LWD and have **no tide predictions**). `noaa_get_station_datums` gives the conversion table.
-- **Units are asymmetric.** `metric` means m/s for wind but **cm/s for currents**; air pressure is millibars and salinity PSU in *both* systems. Every response labels its units.
+- **Units are asymmetric.** `metric` means m/s for wind but **cm/s for currents**; air pressure is millibars and salinity PSU in _both_ systems. Every response labels its units.
 - **Per-product request-span limits** (4 days for 1-minute data, 31 days for 6-minute, 1 year hourly, 10 years for hilo predictions...) are validated client-side with actionable messages before hitting NOAA.
 - **Two station ID schemes.** Water-level/met stations are 7-digit numeric (`9414290`); current stations are alphanumeric (`cb0102`).
 - **Reference vs subordinate stations.** Subordinate (S) prediction stations only support `hilo` predictions, derived by offsets from a reference (R) station.
@@ -171,7 +197,7 @@ These are the things that make NOAA's API tricky — this server encodes them:
 
 ```bash
 npm install
-npm run build        # tsc → dist/
+npm run build        # tsc → dist/ + bundles the MCP Apps chart template (dist/ui/)
 npm test             # vitest unit tests (validation, formatting, astronomy)
 npm run test:live    # end-to-end smoke test against the live NOAA API
 npm run inspector    # MCP Inspector against dist/index.js
@@ -188,18 +214,24 @@ src/
 ├── validation/         # date normalization + per-product span limit enforcement
 ├── format/             # unit labeling, flag legends, markdown/json response shaping
 ├── schemas/            # shared Zod field schemas with nuance-carrying descriptions
-├── services/           # Data API, Metadata API, DPAPI, moon & sun services
-├── tools/              # 25 tool registrations grouped by domain
+├── services/           # Data API, Metadata API, DPAPI, NWS, NDBC, Open-Meteo, moon/sun/solunar
+├── tools/              # 30 tool registrations grouped by domain
+├── ui/                 # MCP Apps resource registration (ui://perigee/charts.html)
 ├── resources/          # noaa:// reference resources
 ├── prompts/            # workflow prompt templates
 └── reference/          # curated NOAA reference content
+ui/src/                 # chart template source (SVG chart core + renderers), bundled by esbuild
 ```
 
 Data sources:
+
 - **Data API** — `api.tidesandcurrents.noaa.gov/api/prod/datagetter`
 - **Metadata API** — `api.tidesandcurrents.noaa.gov/mdapi/prod/webapi`
 - **Derived Product API** — `api.tidesandcurrents.noaa.gov/dpapi/prod/webapi`
-- **Astronomy** — [suncalc](https://github.com/mourner/suncalc), computed locally
+- **NWS Weather API** — `api.weather.gov` (wind + marine forecasts)
+- **NDBC** — `www.ndbc.noaa.gov` realtime buoy text feeds
+- **Open-Meteo Marine** — `marine-api.open-meteo.com` (wave/SST/current models; [CC BY 4.0](https://open-meteo.com/), non-commercial tier)
+- **Astronomy & solunar** — [suncalc](https://github.com/mourner/suncalc), computed locally
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
+        "@modelcontextprotocol/ext-apps": "^1.7.4",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "axios": "^1.7.9",
         "express": "^5.0.0",
@@ -21,6 +22,7 @@
       "devDependencies": {
         "@types/express": "^5.0.0",
         "@types/node": "^22.10.0",
+        "esbuild": "^0.28.1",
         "prettier": "^3.0.3",
         "tsx": "^4.19.2",
         "typescript": "^5.7.2",
@@ -31,9 +33,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.6.tgz",
-      "integrity": "sha512-ShbM/3XxwuxjFiuVBHA+d3j5dyac0aEVVq1oluIDf71hUw0aRF59dV/efUsIwFnR6m8JNM2FjZOzmaZ8yG61kw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -48,9 +50,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.6.tgz",
-      "integrity": "sha512-S8ToEOVfg++AU/bHwdksHNnyLyVM+eMVAOf6yRKFitnwnbwwPNqKr3srzFRe7nzV69RQKb5DgchIX5pt3L53xg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -65,9 +67,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.6.tgz",
-      "integrity": "sha512-hd5zdUarsK6strW+3Wxi5qWws+rJhCCbMiC9QZyzoxfk5uHRIE8T287giQxzVpEvCwuJ9Qjg6bEjcRJcgfLqoA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -82,9 +84,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.6.tgz",
-      "integrity": "sha512-0Z7KpHSr3VBIO9A/1wcT3NTy7EB4oNC4upJ5ye3R7taCc2GUdeynSLArnon5G8scPwaU866d3H4BCrE5xLW25A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -99,9 +101,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.6.tgz",
-      "integrity": "sha512-FFCssz3XBavjxcFxKsGy2DYK5VSvJqa6y5HXljKzhRZ87LvEi13brPrf/wdyl/BbpbMKJNOr1Sd0jtW4Ge1pAA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -116,9 +118,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.6.tgz",
-      "integrity": "sha512-GfXs5kry/TkGM2vKqK2oyiLFygJRqKVhawu3+DOCk7OxLy/6jYkWXhlHwOoTb0WqGnWGAS7sooxbZowy+pK9Yg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -133,9 +135,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.6.tgz",
-      "integrity": "sha512-aoLF2c3OvDn2XDTRvn8hN6DRzVVpDlj2B/F66clWd/FHLiHaG3aVZjxQX2DYphA5y/evbdGvC6Us13tvyt4pWg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -150,9 +152,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.6.tgz",
-      "integrity": "sha512-2SkqTjTSo2dYi/jzFbU9Plt1vk0+nNg8YC8rOXXea+iA3hfNJWebKYPs3xnOUf9+ZWhKAaxnQNUf2X9LOpeiMQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -167,9 +169,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.6.tgz",
-      "integrity": "sha512-SZHQlzvqv4Du5PrKE2faN0qlbsaW/3QQfUUc6yO2EjFcA83xnwm91UbEEVx4ApZ9Z5oG8Bxz4qPE+HFwtVcfyw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -184,9 +186,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.6.tgz",
-      "integrity": "sha512-b967hU0gqKd9Drsh/UuAm21Khpoh6mPBSgz8mKRq4P5mVK8bpA+hQzmm/ZwGVULSNBzKdZPQBRT3+WuVavcWsQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -201,9 +203,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.6.tgz",
-      "integrity": "sha512-aHWdQ2AAltRkLPOsKdi3xv0mZ8fUGPdlKEjIEhxCPm5yKEThcUjHpWB1idN74lfXGnZ5SULQSgtr5Qos5B0bPw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -218,9 +220,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.6.tgz",
-      "integrity": "sha512-VgKCsHdXRSQ7E1+QXGdRPlQ/e08bN6WMQb27/TMfV+vPjjTImuT9PmLXupRlC90S1JeNNW5lzkAEO/McKeJ2yg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -235,9 +237,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.6.tgz",
-      "integrity": "sha512-WViNlpivRKT9/py3kCmkHnn44GkGXVdXfdc4drNmRl15zVQ2+D2uFwdlGh6IuK5AAnGTo2qPB1Djppj+t78rzw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -252,9 +254,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.6.tgz",
-      "integrity": "sha512-wyYKZ9NTdmAMb5730I38lBqVu6cKl4ZfYXIs31Baf8aoOtB4xSGi3THmDYt4BTFHk7/EcVixkOV2uZfwU3Q2Jw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -269,9 +271,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.6.tgz",
-      "integrity": "sha512-KZh7bAGGcrinEj4qzilJ4hqTY3Dg2U82c8bv+e1xqNqZCrCyc+TL9AUEn5WGKDzm3CfC5RODE/qc96OcbIe33w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -286,9 +288,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.6.tgz",
-      "integrity": "sha512-9N1LsTwAuE9oj6lHMyyAM+ucxGiVnEqUdp4v7IaMmrwb06ZTEVCIs3oPPplVsnjPfyjmxwHxHMF8b6vzUVAUGw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -303,9 +305,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.6.tgz",
-      "integrity": "sha512-A6bJB41b4lKFWRKNrWoP2LHsjVzNiaurf7wyj/XtFNTsnPuxwEBWHLty+ZE0dWBKuSK1fvKgrKaNjBS7qbFKig==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -320,9 +322,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.6.tgz",
-      "integrity": "sha512-IjA+DcwoVpjEvyxZddDqBY+uJ2Snc6duLpjmkXm/v4xuS3H+3FkLZlDm9ZsAbF9rsfP3zeA0/ArNDORZgrxR/Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -337,9 +339,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.6.tgz",
-      "integrity": "sha512-dUXuZr5WenIDlMHdMkvDc1FAu4xdWixTCRgP7RQLBOkkGgwuuzaGSYcOpW4jFxzpzL1ejb8yF620UxAqnBrR9g==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -354,9 +356,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.6.tgz",
-      "integrity": "sha512-l8ZCvXP0tbTJ3iaqdNf3pjaOSd5ex/e6/omLIQCVBLmHTlfXW3zAxQ4fnDmPLOB1x9xrcSi/xtCWFwCZRIaEwg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -371,9 +373,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.6.tgz",
-      "integrity": "sha512-hKrmDa0aOFOr71KQ/19JC7az1P0GWtCN1t2ahYAf4O007DHZt/dW8ym5+CUdJhQ/qkZmI1HAF8KkJbEFtCL7gw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -388,9 +390,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.6.tgz",
-      "integrity": "sha512-+SqBcAWoB1fYKmpWoQP4pGtx+pUUC//RNYhFdbcSA16617cchuryuhOCRpPsjCblKukAckWsV+aQ3UKT/RMPcA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -405,9 +407,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.6.tgz",
-      "integrity": "sha512-dyCGxv1/Br7MiSC42qinGL8KkG4kX0pEsdb0+TKhmJZgCUDBGmyo1/ArCjNGiOLiIAgdbWgmWgib4HoCi5t7kA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -422,9 +424,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.6.tgz",
-      "integrity": "sha512-42QOgcZeZOvXfsCBJF5Afw73t4veOId//XD3i+/9gSkhSV6Gk3VPlWncctI+JcOyERv85FUo7RxuxGy+z8A43Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -439,9 +441,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.6.tgz",
-      "integrity": "sha512-4AWhgXmDuYN7rJI6ORB+uU9DHLq/erBbuMoAuB4VWJTu5KtCgcKYPynF0YI1VkBNuEfjNlLrFr9KZPJzrtLkrQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -456,9 +458,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.6.tgz",
-      "integrity": "sha512-NgJPHHbEpLQgDH2MjQu90pzW/5vvXIZ7KOnPyNBm92A6WgZ/7b6fJyUBjoumLqeOQQGqY2QjQxRo97ah4Sj0cA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -490,6 +492,35 @@
       "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/ext-apps": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/ext-apps/-/ext-apps-1.7.4.tgz",
+      "integrity": "sha512-QQqysE549cf/Y0VabBmAACXhj92EhB3t8yVct2BHbkWiPTFA1S91EqTVjYXXcZEefXU0pmHcdObhsNMcomJIOQ==",
+      "license": "MIT",
+      "workspaces": [
+        "examples/*"
+      ],
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
@@ -810,6 +841,12 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
@@ -1411,9 +1448,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.6.tgz",
-      "integrity": "sha512-GVuzuUwtdsghE3ocJ9Bs8PNoF13HNQ5TXbEi2AhvVb8xU1Iwt9Fos9FEamfoee+u/TOsn7GUWc04lz46n2bbTg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1424,32 +1461,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.6",
-        "@esbuild/android-arm": "0.25.6",
-        "@esbuild/android-arm64": "0.25.6",
-        "@esbuild/android-x64": "0.25.6",
-        "@esbuild/darwin-arm64": "0.25.6",
-        "@esbuild/darwin-x64": "0.25.6",
-        "@esbuild/freebsd-arm64": "0.25.6",
-        "@esbuild/freebsd-x64": "0.25.6",
-        "@esbuild/linux-arm": "0.25.6",
-        "@esbuild/linux-arm64": "0.25.6",
-        "@esbuild/linux-ia32": "0.25.6",
-        "@esbuild/linux-loong64": "0.25.6",
-        "@esbuild/linux-mips64el": "0.25.6",
-        "@esbuild/linux-ppc64": "0.25.6",
-        "@esbuild/linux-riscv64": "0.25.6",
-        "@esbuild/linux-s390x": "0.25.6",
-        "@esbuild/linux-x64": "0.25.6",
-        "@esbuild/netbsd-arm64": "0.25.6",
-        "@esbuild/netbsd-x64": "0.25.6",
-        "@esbuild/openbsd-arm64": "0.25.6",
-        "@esbuild/openbsd-x64": "0.25.6",
-        "@esbuild/openharmony-arm64": "0.25.6",
-        "@esbuild/sunos-x64": "0.25.6",
-        "@esbuild/win32-arm64": "0.25.6",
-        "@esbuild/win32-ia32": "0.25.6",
-        "@esbuild/win32-x64": "0.25.6"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escape-html": {
@@ -2613,490 +2650,6 @@
         "fsevents": "~2.3.3"
       }
     },
-    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
-      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/android-arm": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
-      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
-      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/android-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
-      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
-      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
-      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
-      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
-      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
-      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
-      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
-      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
-      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
-      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
-      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
-      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
-      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
-      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
-      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
-      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
-      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
-      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
-      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
-      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
-      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
-      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
-      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tsx/node_modules/esbuild": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
-      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.1",
-        "@esbuild/android-arm": "0.28.1",
-        "@esbuild/android-arm64": "0.28.1",
-        "@esbuild/android-x64": "0.28.1",
-        "@esbuild/darwin-arm64": "0.28.1",
-        "@esbuild/darwin-x64": "0.28.1",
-        "@esbuild/freebsd-arm64": "0.28.1",
-        "@esbuild/freebsd-x64": "0.28.1",
-        "@esbuild/linux-arm": "0.28.1",
-        "@esbuild/linux-arm64": "0.28.1",
-        "@esbuild/linux-ia32": "0.28.1",
-        "@esbuild/linux-loong64": "0.28.1",
-        "@esbuild/linux-mips64el": "0.28.1",
-        "@esbuild/linux-ppc64": "0.28.1",
-        "@esbuild/linux-riscv64": "0.28.1",
-        "@esbuild/linux-s390x": "0.28.1",
-        "@esbuild/linux-x64": "0.28.1",
-        "@esbuild/netbsd-arm64": "0.28.1",
-        "@esbuild/netbsd-x64": "0.28.1",
-        "@esbuild/openbsd-arm64": "0.28.1",
-        "@esbuild/openbsd-x64": "0.28.1",
-        "@esbuild/openharmony-arm64": "0.28.1",
-        "@esbuild/sunos-x64": "0.28.1",
-        "@esbuild/win32-arm64": "0.28.1",
-        "@esbuild/win32-ia32": "0.28.1",
-        "@esbuild/win32-x64": "0.28.1"
-      }
-    },
     "node_modules/type-is": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
@@ -3190,6 +2743,448 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/vite-node/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/vite-node/node_modules/@types/node": {
       "version": "24.0.14",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.14.tgz",
@@ -3200,6 +3195,48 @@
       "peer": true,
       "dependencies": {
         "undici-types": "~7.8.0"
+      }
+    },
+    "node_modules/vite-node/node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
       }
     },
     "node_modules/vite-node/node_modules/undici-types": {
@@ -3359,6 +3396,448 @@
         }
       }
     },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/vitest/node_modules/@vitest/mocker": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
@@ -3384,6 +3863,48 @@
         "vite": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
       }
     },
     "node_modules/vitest/node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ryancardin/noaa-tides-currents-mcp-server",
   "version": "2.0.1",
-  "description": "MCP server for NOAA CO-OPS Tides and Currents: water levels, tide predictions, currents, meteorology, station metadata, datums, high tide flooding, sea level trends, plus sun and moon calculations",
+  "description": "MCP server for NOAA CO-OPS Tides and Currents: water levels, tide predictions, currents, meteorology, station metadata, datums, high tide flooding, sea level trends, plus NDBC buoys, solunar fishing forecasts, marine wave/SST models, sun and moon calculations, and interactive MCP Apps charts",
   "main": "dist/index.js",
   "bin": {
     "noaa-mcp": "dist/index.js"
@@ -13,7 +13,7 @@
   ],
   "type": "module",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && tsc -p tsconfig.ui.json && node scripts/build-ui.mjs",
     "start": "node dist/index.js",
     "start:http": "node dist/index.js --http --port 3000",
     "dev": "tsx src/index.ts",
@@ -32,6 +32,12 @@
     "tide-predictions",
     "mcp",
     "model-context-protocol",
+    "mcp-apps",
+    "fishing",
+    "solunar",
+    "ndbc",
+    "buoy",
+    "marine-weather",
     "api"
   ],
   "author": "Cardin Labs <support@cardinlabs.com> (https://cardinlabs.com)",
@@ -52,6 +58,7 @@
     "node": ">=18"
   },
   "dependencies": {
+    "@modelcontextprotocol/ext-apps": "^1.7.4",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "axios": "^1.7.9",
     "express": "^5.0.0",
@@ -61,6 +68,7 @@
   "devDependencies": {
     "@types/express": "^5.0.0",
     "@types/node": "^22.10.0",
+    "esbuild": "^0.28.1",
     "prettier": "^3.0.3",
     "tsx": "^4.19.2",
     "typescript": "^5.7.2",

--- a/scripts/build-ui.mjs
+++ b/scripts/build-ui.mjs
@@ -1,0 +1,36 @@
+/**
+ * Build the Perigee Charts MCP-app template: bundle ui/src/main.ts with
+ * esbuild (App SDK + chart core inlined, minified, IIFE) and inject it into
+ * the shell page, emitting a single self-contained dist/ui/perigee-charts.html
+ * that the server serves as the ui://perigee/charts.html resource.
+ */
+
+import { build } from "esbuild";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+const result = await build({
+  entryPoints: [resolve(root, "ui/src/main.ts")],
+  bundle: true,
+  minify: true,
+  format: "iife",
+  target: "es2020",
+  write: false,
+  legalComments: "none",
+});
+
+const js = result.outputFiles[0].text;
+const shell = await readFile(resolve(root, "ui/src/shell.html"), "utf-8");
+// The bundle is inlined verbatim; guard against "</script>" inside strings.
+const safeJs = js.replace(/<\/script>/gi, "<\\/script>");
+const html = shell.replace("/*__BUNDLE__*/", () => safeJs);
+
+const outPath = resolve(root, "dist/ui/perigee-charts.html");
+await mkdir(dirname(outPath), { recursive: true });
+await writeFile(outPath, html);
+console.error(
+  `built ${outPath} (${(Buffer.byteLength(html) / 1024).toFixed(1)} KB)`,
+);

--- a/scripts/smoke-live.mjs
+++ b/scripts/smoke-live.mjs
@@ -1,27 +1,36 @@
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 
 const transport = new StdioClientTransport({
-  command: 'node',
-  args: [new URL('../dist/index.js', import.meta.url).pathname],
+  command: "node",
+  args: [new URL("../dist/index.js", import.meta.url).pathname],
 });
-const client = new Client({ name: 'smoke', version: '1.0.0' });
+const client = new Client({ name: "smoke", version: "1.0.0" });
 await client.connect(transport);
 
 const tools = await client.listTools();
-console.log(`TOOLS (${tools.tools.length}):`, tools.tools.map((t) => t.name).join(', '));
+console.log(
+  `TOOLS (${tools.tools.length}):`,
+  tools.tools.map((t) => t.name).join(", "),
+);
 
 const resources = await client.listResources();
-console.log(`RESOURCES (${resources.resources.length}):`, resources.resources.map((r) => r.uri).join(', '));
+console.log(
+  `RESOURCES (${resources.resources.length}):`,
+  resources.resources.map((r) => r.uri).join(", "),
+);
 
 const prompts = await client.listPrompts();
-console.log(`PROMPTS (${prompts.prompts.length}):`, prompts.prompts.map((p) => p.name).join(', '));
+console.log(
+  `PROMPTS (${prompts.prompts.length}):`,
+  prompts.prompts.map((p) => p.name).join(", "),
+);
 
 async function call(name, args) {
   try {
     const result = await client.callTool({ name, arguments: args });
-    const text = result.content?.[0]?.text ?? '';
-    console.log(`\n=== ${name} ${result.isError ? '[ERROR]' : '[OK]'}`);
+    const text = result.content?.[0]?.text ?? "";
+    console.log(`\n=== ${name} ${result.isError ? "[ERROR]" : "[OK]"}`);
     console.log(text.slice(0, 700));
   } catch (e) {
     console.log(`\n=== ${name} [THREW]`, e.message?.slice(0, 300));
@@ -29,55 +38,164 @@ async function call(name, args) {
 }
 
 // Data API
-await call('noaa_get_water_levels', { station: '8454000', date: 'latest' });
-await call('noaa_get_tide_predictions', { station: '9414290', begin_date: '2026-07-04', end_date: '2026-07-05', interval: 'hilo' });
-await call('noaa_get_water_level_summaries', { station: '8454000', product: 'high_low', begin_date: '2026-06-01', end_date: '2026-06-08' });
-await call('noaa_get_water_level_summaries', { station: '9075014', product: 'daily_mean', begin_date: '2026-06-01', end_date: '2026-06-15', datum: 'IGLD' });
-await call('noaa_get_currents', { station: 'bh0101', date: 'recent' });
-await call('noaa_get_current_predictions', { station: 'cb0102', begin_date: '2026-07-04', end_date: '2026-07-05', interval: 'max_slack' });
-await call('noaa_get_meteorological_data', { station: '8454000', product: 'wind', date: 'latest' });
-await call('noaa_get_meteorological_data', { station: '8454000', product: 'water_temperature', date: 'latest', units: 'metric' });
+await call("noaa_get_water_levels", { station: "8454000", date: "latest" });
+await call("noaa_get_tide_predictions", {
+  station: "9414290",
+  begin_date: "2026-07-04",
+  end_date: "2026-07-05",
+  interval: "hilo",
+});
+await call("noaa_get_water_level_summaries", {
+  station: "8454000",
+  product: "high_low",
+  begin_date: "2026-06-01",
+  end_date: "2026-06-08",
+});
+await call("noaa_get_water_level_summaries", {
+  station: "9075014",
+  product: "daily_mean",
+  begin_date: "2026-06-01",
+  end_date: "2026-06-15",
+  datum: "IGLD",
+});
+await call("noaa_get_currents", { station: "bh0101", date: "recent" });
+await call("noaa_get_current_predictions", {
+  station: "cb0102",
+  begin_date: "2026-07-04",
+  end_date: "2026-07-05",
+  interval: "max_slack",
+});
+await call("noaa_get_meteorological_data", {
+  station: "8454000",
+  product: "wind",
+  date: "latest",
+});
+await call("noaa_get_meteorological_data", {
+  station: "8454000",
+  product: "water_temperature",
+  date: "latest",
+  units: "metric",
+});
 
 // Validation failures (should be actionable errors, not upstream junk)
-await call('noaa_get_water_levels', { station: '8454000', begin_date: '2026-01-01', end_date: '2026-03-15' });
-await call('noaa_get_water_levels', { station: '8454000' });
-await call('noaa_get_tide_predictions', { station: '9075014', date: 'today' }); // Great Lakes -> upstream error w/ hint
+await call("noaa_get_water_levels", {
+  station: "8454000",
+  begin_date: "2026-01-01",
+  end_date: "2026-03-15",
+});
+await call("noaa_get_water_levels", { station: "8454000" });
+await call("noaa_get_tide_predictions", { station: "9075014", date: "today" }); // Great Lakes -> upstream error w/ hint
 
 // Metadata
-await call('noaa_search_stations', { name: 'San Francisco', type: 'waterlevels' });
-await call('noaa_find_nearest_stations', { latitude: 42.35, longitude: -71.05, type: 'tidepredictions', limit: 5 });
-await call('noaa_get_station_info', { station: '8454000', expand: ['sensors', 'floodlevels'] });
-await call('noaa_get_station_datums', { station: '8454000' });
-await call('noaa_get_harmonic_constituents', { station: '8454000' });
-await call('noaa_get_prediction_offsets', { station: '8447930', kind: 'tide' });
+await call("noaa_search_stations", {
+  name: "San Francisco",
+  type: "waterlevels",
+});
+await call("noaa_find_nearest_stations", {
+  latitude: 42.35,
+  longitude: -71.05,
+  type: "tidepredictions",
+  limit: 5,
+});
+await call("noaa_get_station_info", {
+  station: "8454000",
+  expand: ["sensors", "floodlevels"],
+});
+await call("noaa_get_station_datums", { station: "8454000" });
+await call("noaa_get_harmonic_constituents", { station: "8454000" });
+await call("noaa_get_prediction_offsets", { station: "8447930", kind: "tide" });
 
 // DPAPI
-await call('noaa_get_sea_level_trends', { station: '8454000' });
-await call('noaa_get_extreme_water_levels', { station: '8454000' });
-await call('noaa_get_top_ten_water_levels', { station: '8454000' });
-await call('noaa_get_high_tide_flooding', { station: '8454000', report: 'annual', range: 5 });
-await call('noaa_get_sea_level_rise_projections', { station: '8454000', scenario: 'intermediate', projection_year: 2050 });
+await call("noaa_get_sea_level_trends", { station: "8454000" });
+await call("noaa_get_extreme_water_levels", { station: "8454000" });
+await call("noaa_get_top_ten_water_levels", { station: "8454000" });
+await call("noaa_get_high_tide_flooding", {
+  station: "8454000",
+  report: "annual",
+  range: 5,
+});
+await call("noaa_get_sea_level_rise_projections", {
+  station: "8454000",
+  scenario: "intermediate",
+  projection_year: 2050,
+});
 
 // Astronomy
-await call('astro_get_moon_phase', { date: '2026-07-04' });
-await call('astro_get_next_moon_phase', { phase: 'Full Moon', date: '2026-07-04', count: 2 });
-await call('astro_get_sun_times', { latitude: 41.8, longitude: -71.4, date: '2026-07-04', timezone: 'America/New_York' });
-await call('astro_get_next_sun_event', { event: 'goldenHourStart', latitude: 41.8, longitude: -71.4, date: '2026-07-04' });
+await call("astro_get_moon_phase", { date: "2026-07-04" });
+await call("astro_get_next_moon_phase", {
+  phase: "Full Moon",
+  date: "2026-07-04",
+  count: 2,
+});
+await call("astro_get_sun_times", {
+  latitude: 41.8,
+  longitude: -71.4,
+  date: "2026-07-04",
+  timezone: "America/New_York",
+});
+await call("astro_get_next_sun_event", {
+  event: "goldenHourStart",
+  latitude: 41.8,
+  longitude: -71.4,
+  date: "2026-07-04",
+});
+await call("astro_get_solunar_forecast", {
+  latitude: 41.8,
+  longitude: -71.4,
+  date: "2026-07-04",
+  timezone: "America/New_York",
+});
+
+// Fishing conditions (NDBC buoys, pressure trend, Open-Meteo marine models)
+await call("ndbc_find_nearest_buoys", {
+  latitude: 41.4,
+  longitude: -70.8,
+  limit: 5,
+});
+await call("ndbc_get_buoy_observations", { buoy_id: "44018", hours: 6 });
+await call("ndbc_get_buoy_observations", { buoy_id: "zzzzz", hours: 6 }); // unknown buoy -> actionable error
+await call("noaa_get_pressure_trend", { station: "8454000" });
+await call("openmeteo_get_marine_forecast", {
+  latitude: 41.5,
+  longitude: -69.9,
+  days: 2,
+});
+await call("openmeteo_get_marine_forecast", {
+  latitude: 39.0,
+  longitude: -105.5,
+  days: 1,
+}); // inland -> actionable error
 
 // NWS forecasts (Sargent TX / Matagorda Bay — a marine-typed gridpoint)
-await call('nws_get_wind_forecast', { latitude: 28.77, longitude: -95.62, hours: 12 });
-await call('nws_get_wind_forecast', { latitude: 28.77, longitude: -95.62, hours: 6, units: 'metric' });
-await call('nws_get_marine_forecast', { latitude: 28.77, longitude: -95.62 });
-await call('nws_get_marine_forecast', { latitude: 39.0, longitude: -105.5 }); // inland -> actionable error
+await call("nws_get_wind_forecast", {
+  latitude: 28.77,
+  longitude: -95.62,
+  hours: 12,
+});
+await call("nws_get_wind_forecast", {
+  latitude: 28.77,
+  longitude: -95.62,
+  hours: 6,
+  units: "metric",
+});
+await call("nws_get_marine_forecast", { latitude: 28.77, longitude: -95.62 });
+await call("nws_get_marine_forecast", { latitude: 39.0, longitude: -105.5 }); // inland -> actionable error
 
 // Reference + resources + prompts
-await call('noaa_get_reference_guide', { topic: 'units' });
-const res = await client.readResource({ uri: 'noaa://reference/datums' });
-console.log('\n=== resource noaa://reference/datums [OK]');
+await call("noaa_get_reference_guide", { topic: "units" });
+const res = await client.readResource({ uri: "noaa://reference/datums" });
+console.log("\n=== resource noaa://reference/datums [OK]");
 console.log(res.contents[0].text.slice(0, 300));
-const prompt = await client.getPrompt({ name: 'tide_report', arguments: { location: 'Boston', date: '2026-07-10' } });
-console.log('\n=== prompt tide_report [OK]');
+const ui = await client.readResource({ uri: "ui://perigee/charts.html" });
+console.log(
+  `\n=== resource ui://perigee/charts.html [${ui.contents[0].mimeType === "text/html;profile=mcp-app" && ui.contents[0].text.length > 10000 ? "OK" : "ERROR"}] ${ui.contents[0].text.length} bytes`,
+);
+const prompt = await client.getPrompt({
+  name: "tide_report",
+  arguments: { location: "Boston", date: "2026-07-10" },
+});
+console.log("\n=== prompt tide_report [OK]");
 console.log(prompt.messages[0].content.text.slice(0, 200));
 
 await client.close();
-console.log('\nSMOKE TEST COMPLETE');
+console.log("\nSMOKE TEST COMPLETE");

--- a/src/client/http.ts
+++ b/src/client/http.ts
@@ -17,7 +17,9 @@ import {
   DPAPI_BASE_URL,
   MAX_RETRIES,
   METADATA_API_BASE_URL,
+  NDBC_BASE_URL,
   NWS_API_BASE_URL,
+  OPEN_METEO_MARINE_BASE_URL,
   NWS_USER_AGENT,
   REQUEST_TIMEOUT_MS,
 } from "../constants.js";
@@ -284,6 +286,76 @@ export async function fetchNwsApi<T = Record<string, unknown>>(
   } catch (error) {
     if (error instanceof NoaaApiError) throw error;
     throw toNwsError(error);
+  }
+}
+
+/**
+ * NDBC GET: path like "/data/realtime2/41013.txt" or "/activestations.xml".
+ * NDBC serves plain text/XML (no JSON API) and answers unknown stations with
+ * a bare 404 HTML page, so responses come back as raw strings.
+ */
+export async function fetchNdbcText(path: string): Promise<string> {
+  try {
+    let lastError: unknown;
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      try {
+        const response = await http.get<string>(`${NDBC_BASE_URL}${path}`, {
+          responseType: "text",
+          // Axios auto-parses JSON-looking bodies; force text through.
+          transformResponse: [(data: string) => data],
+          headers: { Accept: "text/plain, application/xml, text/xml, */*" },
+        });
+        return response.data;
+      } catch (error) {
+        lastError = error;
+        if (attempt < MAX_RETRIES && isRetryable(error)) {
+          await sleep(500 * Math.pow(3, attempt));
+          continue;
+        }
+        throw error;
+      }
+    }
+    throw lastError;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response?.status === 404) {
+      throw new NoaaApiError(
+        "NOAA NDBC error: not found (404). The buoy ID may be wrong, or this station is not reporting realtime data. Find active buoys with ndbc_find_nearest_buoys.",
+        404,
+      );
+    }
+    throw toNoaaError(error, "NDBC");
+  }
+}
+
+/**
+ * Open-Meteo Marine API GET. Error bodies look like
+ * {"error": true, "reason": "..."} — surfaced with the reason attached.
+ */
+export async function fetchOpenMeteoMarine<T = Record<string, unknown>>(
+  params: Record<string, string | number | boolean | undefined | null>,
+): Promise<T> {
+  try {
+    const data = await getWithRetry<T>(
+      OPEN_METEO_MARINE_BASE_URL,
+      cleanParams(params),
+    );
+    const body = data as { error?: boolean; reason?: string };
+    if (body && body.error) {
+      throw new NoaaApiError(
+        `Open-Meteo Marine API error: ${body.reason ?? "unknown error"}.`,
+      );
+    }
+    return data;
+  } catch (error) {
+    if (error instanceof NoaaApiError) throw error;
+    if (axios.isAxiosError(error) && error.response) {
+      const body = error.response.data as { reason?: string } | undefined;
+      throw new NoaaApiError(
+        `Open-Meteo Marine API error: ${body?.reason ?? `HTTP ${error.response.status}`}. The point may be on land — marine model cells cover ocean only; try a coordinate further offshore.`,
+        error.response.status,
+      );
+    }
+    throw toNoaaError(error, "Open-Meteo Marine");
   }
 }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,6 +18,21 @@ export const DPAPI_BASE_URL =
 export const NWS_API_BASE_URL = "https://api.weather.gov";
 
 /**
+ * NOAA NDBC — National Data Buoy Center. Realtime observations are plain
+ * fixed-format text files (no JSON API): /data/realtime2/{ID}.txt, and the
+ * active-station directory is /activestations.xml.
+ */
+export const NDBC_BASE_URL = "https://www.ndbc.noaa.gov";
+
+/**
+ * Open-Meteo Marine API — keyless JSON wave/swell/SST/current model forecasts
+ * (GFS-Wave, ECMWF WAM, ICON-Wave blends). Free for non-commercial use with
+ * attribution; data is model output, not observations.
+ */
+export const OPEN_METEO_MARINE_BASE_URL =
+  "https://marine-api.open-meteo.com/v1/marine";
+
+/**
  * NWS requires a descriptive User-Agent identifying the application and a
  * contact point (their abuse-mitigation mechanism; the API has no keys).
  */
@@ -51,4 +66,8 @@ export const CACHE_TTL = {
   nwsPoint: 6 * 60 * 60 * 1000,
   /** NWS forecasts and marine text products update roughly hourly. */
   nwsForecast: 30 * 60 * 1000,
+  /** NDBC active-station directory (updated daily upstream). */
+  ndbcStations: 6 * 60 * 60 * 1000,
+  /** NDBC realtime observations post roughly every 10 minutes to hourly. */
+  ndbcObservations: 10 * 60 * 1000,
 } as const;

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,10 @@
  * Exposes NOAA CO-OPS data (water levels, tide predictions, currents,
  * meteorology), station metadata (datums, harmonic constituents, offsets),
  * derived products (sea level trends/projections, extreme water levels,
- * high tide flooding), and local sun/moon calculations.
+ * high tide flooding), NDBC buoy observations, Open-Meteo marine model
+ * forecasts, and local sun/moon/solunar calculations. Tide, solunar, buoy,
+ * and marine-forecast tools also render interactive charts in MCP hosts
+ * that support the MCP Apps extension.
  *
  * Transport: stdio by default (for MCP client integration); pass --http
  * [--port N] for a stateless streamable-HTTP endpoint at /mcp.

--- a/src/reference/content.ts
+++ b/src/reference/content.ts
@@ -15,6 +15,7 @@ export const REFERENCE_TOPICS = [
   "quality_flags",
   "date_formats",
   "marine_forecast",
+  "fishing",
 ] as const;
 
 export type ReferenceTopic = (typeof REFERENCE_TOPICS)[number];
@@ -223,6 +224,37 @@ How it works:
 - Coverage: US and territories only. No API key; forecasts update ~hourly.
 - Forecast wind direction is where the wind blows FROM, degrees true — same
   convention as CO-OPS wind observations.`,
+
+  fishing: `# Fishing Conditions Toolkit
+
+The data layers the major fishing apps combine, and which tool serves each:
+
+| Layer | Tool | Source |
+|---|---|---|
+| Solunar bite times (majors/minors, day rating, activity curve) | astro_get_solunar_forecast | computed locally (lunar transit/rise/set) |
+| Tide stage & high/low times | noaa_get_tide_predictions | NOAA CO-OPS harmonics |
+| Observed waves, water temp, offshore wind | ndbc_get_buoy_observations (find IDs with ndbc_find_nearest_buoys) | NOAA NDBC realtime |
+| Barometric pressure trend (pre/post-frontal bite logic) | noaa_get_pressure_trend | derived from CO-OPS air_pressure |
+| Wave/swell/SST/current FORECAST anywhere at sea | openmeteo_get_marine_forecast | Open-Meteo wave-model blend |
+| Wind forecast | nws_get_wind_forecast | NWS gridpoints (US only) |
+| Marine narrative & advisories | nws_get_marine_forecast | NWS Coastal Waters Forecast |
+| Moon phase / spring-neap context | astro_get_moon_phase | computed locally |
+
+How anglers combine them:
+- SOLUNAR sets the day's candidate windows (majors > minors; windows that
+  overlap dawn/dusk are strongest). It is a heuristic — conditions rule.
+- PRESSURE TREND modulates expectations: falling = feed window ahead of a
+  front; sharp post-frontal rise = tough bite (fish deeper/slower).
+- TIDE STAGE picks the spot: moving water (mid-tide, or the hour around a
+  high/low turn) beats slack at most inshore spots.
+- WIND/WAVES decide safety and water clarity; SST breaks concentrate bait.
+
+ID namespaces differ: CO-OPS stations ("8454000", "cb0102") vs NDBC buoys
+("44018", "BUZM3") — never mix them across tools.
+
+Solunar, tide-prediction, buoy-observation, and marine-forecast results
+render interactive charts in MCP hosts that support MCP Apps (Claude,
+ChatGPT, VS Code, ...); other hosts get the same data as markdown + JSON.`,
 };
 
 /** One-line summaries used in resource listings and the guide index. */
@@ -237,4 +269,6 @@ export const REFERENCE_SUMMARIES: Record<ReferenceTopic, string> = {
   quality_flags: "Data quality fields (v/s/f/q), flag letters, HH/H/L/LL",
   date_formats: "Accepted date formats and parameter combinations",
   marine_forecast: "NWS wind & marine forecast tools vs CO-OPS observations",
+  fishing:
+    "Combining solunar, tide, buoy, pressure-trend, and marine-model tools for bite planning",
 };

--- a/src/services/ndbc.ts
+++ b/src/services/ndbc.ts
@@ -1,0 +1,267 @@
+/**
+ * NOAA NDBC (National Data Buoy Center) — realtime buoy observations.
+ *
+ * NDBC has no JSON API; it publishes fixed-format text files:
+ *  - /activestations.xml — the active-station directory (id, lat/lon, name,
+ *    type, and per-sensor "y/n" flags), refreshed daily.
+ *  - /data/realtime2/{ID}.txt — last ~45 days of standard meteorological
+ *    observations. Two "#"-prefixed header lines carry column names then
+ *    units; "MM" marks missing values; rows are NEWEST FIRST. Column ORDER
+ *    is stable but parsed by header NAME here anyway, defensively.
+ *
+ * NDBC units are fixed (m/s wind, meters, hPa, °C, nmi) regardless of any
+ * user preference — conversion to english units happens at the tool layer.
+ */
+
+import { cache } from "../client/cache.js";
+import { fetchNdbcText, NoaaApiError } from "../client/http.js";
+import { CACHE_TTL } from "../constants.js";
+import { haversineKm } from "./metadata-api.js";
+
+// ---------------------------------------------------------------------------
+// Active station directory
+// ---------------------------------------------------------------------------
+
+export interface NdbcStation {
+  id: string;
+  name: string;
+  lat: number;
+  lon: number;
+  /** e.g. "buoy", "fixed", "dart", "oilrig", "usv". */
+  type: string;
+  owner?: string;
+  program?: string;
+  /** Reports standard meteorology (wind/pressure/temps). */
+  has_met: boolean;
+  /** Reports currents. */
+  has_currents: boolean;
+  /** Reports water quality. */
+  has_water_quality: boolean;
+}
+
+/**
+ * Parse activestations.xml. The file is flat, one self-closing <station …/>
+ * per line, so attribute-level regex parsing is safe and avoids an XML
+ * dependency. Stations missing id/lat/lon are skipped.
+ */
+export function parseActiveStations(xml: string): NdbcStation[] {
+  const stations: NdbcStation[] = [];
+  const tags = xml.match(/<station\b[^>]*\/>/g) ?? [];
+  for (const tag of tags) {
+    const attr = (name: string): string | undefined => {
+      const match = tag.match(new RegExp(`\\b${name}="([^"]*)"`));
+      return match?.[1];
+    };
+    const id = attr("id");
+    const lat = Number(attr("lat"));
+    const lon = Number(attr("lon"));
+    if (!id || Number.isNaN(lat) || Number.isNaN(lon)) continue;
+    stations.push({
+      id: id.toUpperCase(),
+      name: decodeXmlEntities(attr("name") ?? id),
+      lat,
+      lon,
+      type: attr("type") ?? "unknown",
+      owner: attr("owner") ? decodeXmlEntities(attr("owner")!) : undefined,
+      program: attr("pgm") ? decodeXmlEntities(attr("pgm")!) : undefined,
+      has_met: attr("met") === "y",
+      has_currents: attr("currents") === "y",
+      has_water_quality: attr("waterquality") === "y",
+    });
+  }
+  return stations;
+}
+
+function decodeXmlEntities(value: string): string {
+  return value
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&#(\d+);/g, (_, code) => String.fromCharCode(Number(code)));
+}
+
+export async function listActiveStations(): Promise<NdbcStation[]> {
+  return cache.getOrLoad(
+    "ndbc:activestations",
+    CACHE_TTL.ndbcStations,
+    async () => {
+      const xml = await fetchNdbcText("/activestations.xml");
+      const stations = parseActiveStations(xml);
+      if (stations.length === 0) {
+        throw new NoaaApiError(
+          "NOAA NDBC error: the active-station directory came back empty or in an unexpected format.",
+        );
+      }
+      return stations;
+    },
+  );
+}
+
+export interface NdbcStationWithDistance extends NdbcStation {
+  distance_km: number;
+  distance_mi: number;
+}
+
+export async function findNearestBuoys(
+  latitude: number,
+  longitude: number,
+  limit: number,
+  options: { requireMet?: boolean; maxDistanceKm?: number } = {},
+): Promise<NdbcStationWithDistance[]> {
+  const stations = await listActiveStations();
+  return stations
+    .filter((s) => !options.requireMet || s.has_met)
+    .map((s) => {
+      const distance_km = haversineKm(latitude, longitude, s.lat, s.lon);
+      return { ...s, distance_km, distance_mi: distance_km * 0.621371 };
+    })
+    .filter(
+      (s) =>
+        options.maxDistanceKm === undefined ||
+        s.distance_km <= options.maxDistanceKm,
+    )
+    .sort((a, b) => a.distance_km - b.distance_km)
+    .slice(0, limit);
+}
+
+// ---------------------------------------------------------------------------
+// Realtime standard meteorological observations (…/realtime2/{ID}.txt)
+// ---------------------------------------------------------------------------
+
+export interface NdbcObservation {
+  /** UTC observation instant, ISO 8601. */
+  time: string;
+  /** Direction the wind blows FROM, degrees true. */
+  wind_dir_deg: number | null;
+  /** m/s. */
+  wind_speed_ms: number | null;
+  /** m/s. */
+  wind_gust_ms: number | null;
+  /** Significant wave height, meters. */
+  wave_height_m: number | null;
+  /** Dominant (peak) wave period, seconds. */
+  dominant_period_s: number | null;
+  /** Average wave period, seconds. */
+  average_period_s: number | null;
+  /** Direction dominant-period waves come FROM, degrees true. */
+  mean_wave_dir_deg: number | null;
+  /** Sea-level pressure, hPa (= millibars). */
+  pressure_hpa: number | null;
+  /** hPa change over the last 3 hours (negative = falling). */
+  pressure_tendency_hpa: number | null;
+  air_temp_c: number | null;
+  water_temp_c: number | null;
+  dewpoint_c: number | null;
+  /** Nautical miles. */
+  visibility_nmi: number | null;
+  /** Water level above/below MLLW, feet (rarely reported). */
+  tide_ft: number | null;
+}
+
+/** Map realtime2 column names to NdbcObservation fields. */
+const REALTIME2_COLUMNS: Record<string, keyof NdbcObservation> = {
+  WDIR: "wind_dir_deg",
+  WSPD: "wind_speed_ms",
+  GST: "wind_gust_ms",
+  WVHT: "wave_height_m",
+  DPD: "dominant_period_s",
+  APD: "average_period_s",
+  MWD: "mean_wave_dir_deg",
+  PRES: "pressure_hpa",
+  PTDY: "pressure_tendency_hpa",
+  ATMP: "air_temp_c",
+  WTMP: "water_temp_c",
+  DEWP: "dewpoint_c",
+  VIS: "visibility_nmi",
+  TIDE: "tide_ft",
+};
+
+/**
+ * Parse a realtime2 standard-met file. Columns are resolved from the first
+ * header line by name; "MM" (and blank) cells become null. Rows arrive
+ * newest-first and are returned that way.
+ */
+export function parseRealtime2(text: string): NdbcObservation[] {
+  const lines = text.split("\n").filter((l) => l.trim().length > 0);
+  if (lines.length < 2 || !lines[0].startsWith("#")) {
+    throw new NoaaApiError(
+      "NOAA NDBC error: unexpected realtime2 file format (missing header). The station may not publish standard meteorological data.",
+    );
+  }
+  const headers = lines[0].replace(/^#/, "").trim().split(/\s+/);
+  const observations: NdbcObservation[] = [];
+  for (const line of lines) {
+    if (line.startsWith("#")) continue;
+    const cells = line.trim().split(/\s+/);
+    if (cells.length < 5) continue;
+    // First five columns are always YY MM DD hh mm (4-digit year).
+    const [year, month, day, hour, minute] = cells.map(Number);
+    if ([year, month, day, hour, minute].some(Number.isNaN)) continue;
+    const obs: NdbcObservation = {
+      time: new Date(
+        Date.UTC(year, month - 1, day, hour, minute),
+      ).toISOString(),
+      wind_dir_deg: null,
+      wind_speed_ms: null,
+      wind_gust_ms: null,
+      wave_height_m: null,
+      dominant_period_s: null,
+      average_period_s: null,
+      mean_wave_dir_deg: null,
+      pressure_hpa: null,
+      pressure_tendency_hpa: null,
+      air_temp_c: null,
+      water_temp_c: null,
+      dewpoint_c: null,
+      visibility_nmi: null,
+      tide_ft: null,
+    };
+    for (let i = 5; i < headers.length && i < cells.length; i++) {
+      const field = REALTIME2_COLUMNS[headers[i]];
+      if (!field) continue;
+      const raw = cells[i];
+      if (raw === "MM" || raw === "") continue;
+      const value = Number(raw);
+      if (!Number.isNaN(value)) {
+        (obs as unknown as Record<string, number>)[field] = value;
+      }
+    }
+    observations.push(obs);
+  }
+  return observations;
+}
+
+export interface BuoyObservations {
+  station_id: string;
+  station?: NdbcStation;
+  observations: NdbcObservation[];
+}
+
+/**
+ * Latest realtime observations for a buoy, newest first, trimmed to the
+ * requested window. Station metadata is attached when the directory knows
+ * the ID (realtime2 also serves some non-directory stations; that's fine).
+ */
+export async function getBuoyObservations(
+  stationId: string,
+  hoursBack: number,
+): Promise<BuoyObservations> {
+  const id = stationId.trim().toUpperCase();
+  const text = await cache.getOrLoad(
+    `ndbc:realtime2:${id}`,
+    CACHE_TTL.ndbcObservations,
+    () => fetchNdbcText(`/data/realtime2/${id}.txt`),
+  );
+  const all = parseRealtime2(text);
+  const cutoff = Date.now() - hoursBack * 3_600_000;
+  const observations = all.filter((o) => Date.parse(o.time) >= cutoff);
+  let station: NdbcStation | undefined;
+  try {
+    station = (await listActiveStations()).find((s) => s.id === id);
+  } catch {
+    // Directory lookup is best-effort decoration; observations still stand.
+  }
+  return { station_id: id, station, observations };
+}

--- a/src/services/open-meteo.ts
+++ b/src/services/open-meteo.ts
@@ -1,0 +1,123 @@
+/**
+ * Open-Meteo Marine API — model wave/swell/SST/surface-current forecasts for
+ * any ocean coordinate (the "virtual buoy" concept commercial apps sell).
+ *
+ * Mechanics verified against the public docs: hourly arrays come back as
+ * parallel columns under `hourly` with units in `hourly_units`; timestamps
+ * are "YYYY-MM-DDTHH:mm" in the requested timezone (UTC here, so a "Z" is
+ * appended); missing cells are null. Values are MODEL OUTPUT (GFS-Wave /
+ * ECMWF WAM / ICON blends), not observations — cross-check against a real
+ * NDBC buoy when one is nearby. Free tier is non-commercial with attribution.
+ */
+
+import { cache } from "../client/cache.js";
+import { fetchOpenMeteoMarine } from "../client/http.js";
+import { CACHE_TTL } from "../constants.js";
+
+export interface MarineHourlySample {
+  /** UTC instant, ISO 8601. */
+  time: string;
+  /** Combined significant wave height, meters. */
+  wave_height_m: number | null;
+  /** Direction combined waves come FROM, degrees true. */
+  wave_direction_deg: number | null;
+  /** Combined wave period, seconds. */
+  wave_period_s: number | null;
+  /** Wind-wave (local sea) component height, meters. */
+  wind_wave_height_m: number | null;
+  wind_wave_period_s: number | null;
+  /** Primary swell component height, meters. */
+  swell_wave_height_m: number | null;
+  swell_wave_direction_deg: number | null;
+  swell_wave_period_s: number | null;
+  /** Sea surface temperature, °C. */
+  sea_surface_temp_c: number | null;
+  /** Surface current speed, km/h (Open-Meteo's native unit). */
+  current_velocity_kmh: number | null;
+  /** Direction the current flows TOWARD, degrees true. */
+  current_direction_deg: number | null;
+}
+
+export interface MarineForecast {
+  latitude: number;
+  longitude: number;
+  samples: MarineHourlySample[];
+}
+
+interface OpenMeteoMarineResponse {
+  latitude: number;
+  longitude: number;
+  hourly?: {
+    time?: string[];
+    wave_height?: Array<number | null>;
+    wave_direction?: Array<number | null>;
+    wave_period?: Array<number | null>;
+    wind_wave_height?: Array<number | null>;
+    wind_wave_period?: Array<number | null>;
+    swell_wave_height?: Array<number | null>;
+    swell_wave_direction?: Array<number | null>;
+    swell_wave_period?: Array<number | null>;
+    sea_surface_temperature?: Array<number | null>;
+    ocean_current_velocity?: Array<number | null>;
+    ocean_current_direction?: Array<number | null>;
+  };
+}
+
+const HOURLY_VARS = [
+  "wave_height",
+  "wave_direction",
+  "wave_period",
+  "wind_wave_height",
+  "wind_wave_period",
+  "swell_wave_height",
+  "swell_wave_direction",
+  "swell_wave_period",
+  "sea_surface_temperature",
+  "ocean_current_velocity",
+  "ocean_current_direction",
+].join(",");
+
+export async function getMarineForecast(
+  latitude: number,
+  longitude: number,
+  days: number,
+): Promise<MarineForecast> {
+  const key = `openmeteo:marine:${latitude.toFixed(3)},${longitude.toFixed(3)}:${days}`;
+  return cache.getOrLoad(key, CACHE_TTL.nwsForecast, async () => {
+    const data = await fetchOpenMeteoMarine<OpenMeteoMarineResponse>({
+      latitude,
+      longitude,
+      forecast_days: days,
+      timezone: "UTC",
+      // "sea" makes Open-Meteo snap coastal coordinates to the nearest
+      // ocean model cell instead of returning all-null land cells.
+      cell_selection: "sea",
+      hourly: HOURLY_VARS,
+    });
+    const h = data.hourly ?? {};
+    const times = h.time ?? [];
+    const at = (
+      column: Array<number | null> | undefined,
+      i: number,
+    ): number | null => {
+      const v = column?.[i];
+      return v === undefined || v === null || Number.isNaN(v) ? null : v;
+    };
+    const samples: MarineHourlySample[] = times.map((t, i) => ({
+      // "2026-07-09T14:00" (UTC, no zone suffix) → full ISO instant.
+      time: t.length === 16 ? `${t}:00Z` : `${t}Z`,
+      wave_height_m: at(h.wave_height, i),
+      wave_direction_deg: at(h.wave_direction, i),
+      wave_period_s: at(h.wave_period, i),
+      wind_wave_height_m: at(h.wind_wave_height, i),
+      wind_wave_period_s: at(h.wind_wave_period, i),
+      swell_wave_height_m: at(h.swell_wave_height, i),
+      swell_wave_direction_deg: at(h.swell_wave_direction, i),
+      swell_wave_period_s: at(h.swell_wave_period, i),
+      sea_surface_temp_c: at(h.sea_surface_temperature, i),
+      current_velocity_kmh: at(h.ocean_current_velocity, i),
+      current_direction_deg: at(h.ocean_current_direction, i),
+    }));
+    return { latitude: data.latitude, longitude: data.longitude, samples };
+  });
+}

--- a/src/services/solunar-service.ts
+++ b/src/services/solunar-service.ts
@@ -1,0 +1,471 @@
+/**
+ * Solunar (bite-time) forecasting, computed locally from moon and sun
+ * geometry — the same theory the big fishing apps implement:
+ *
+ *  - MAJOR periods (~2h): centered on lunar transit — the moon crossing the
+ *    observer's meridian overhead ("moon overhead") or the antimeridian
+ *    beneath the observer ("moon underfoot").
+ *  - MINOR periods (~1.5h): centered on moonrise and moonset.
+ *  - Day rating: strongest near new/full moon (syzygy — also spring tides),
+ *    boosted when the moon is near perigee and when a solunar period
+ *    overlaps dawn or dusk.
+ *
+ * Transits are found by scanning the moon's altitude at one-minute steps
+ * across the local day: a local maximum is the overhead transit, a local
+ * minimum the underfoot transit. suncalc has no transit function, and the
+ * lunar day is ~24h50m, so a calendar day can lack one (or both) transits.
+ *
+ * This is folklore-grade forecasting, not physics: the output encodes the
+ * conventional solunar tables, and the rating explains its own factors so
+ * agents can weigh them against real conditions (weather, tide, pressure).
+ */
+
+import SunCalc from "suncalc";
+
+export interface SolunarPeriod {
+  /** "major" = lunar transit window (~2h), "minor" = moonrise/set window (~1.5h). */
+  kind: "major" | "minor";
+  /** Which lunar event anchors the window. */
+  event: "moon_overhead" | "moon_underfoot" | "moonrise" | "moonset";
+  /** Window start, ISO UTC. */
+  start: string;
+  /** Event instant (window center), ISO UTC. */
+  peak: string;
+  /** Window end, ISO UTC. */
+  end: string;
+  /** True when the window overlaps dawn (sunrise ±30m) or dusk (sunset ±30m). */
+  overlaps_twilight: boolean;
+}
+
+export interface SolunarRatingFactor {
+  factor: string;
+  points: number;
+  max_points: number;
+  detail: string;
+}
+
+export interface SolunarDay {
+  /** Local calendar date the forecast covers. */
+  date: string;
+  latitude: number;
+  longitude: number;
+  /** IANA zone used for the day boundaries, or a fixed UTC offset derived from longitude. */
+  time_basis: string;
+  moon_phase: string;
+  moon_illumination: number;
+  /** Days since new moon within the 29.53-day cycle. */
+  moon_age_days: number;
+  moon_distance_km: number;
+  moonrise: string | null;
+  moonset: string | null;
+  moon_overhead: string | null;
+  moon_underfoot: string | null;
+  sunrise: string | null;
+  sunset: string | null;
+  periods: SolunarPeriod[];
+  /** 0–100 composite day quality. */
+  rating: number;
+  rating_label: "Poor" | "Fair" | "Good" | "Very Good" | "Excellent";
+  rating_factors: SolunarRatingFactor[];
+  /**
+   * Predicted feeding-activity curve across the local day: 48 half-hour
+   * samples, each 0–100. Sum of bumps centered on each period peak (majors
+   * weighted over minors), scaled by the day rating.
+   */
+  hourly_activity: Array<{ time: string; activity: number }>;
+}
+
+const MINUTE_MS = 60_000;
+const HOUR_MS = 3_600_000;
+const DAY_MS = 24 * HOUR_MS;
+const LUNAR_MONTH_DAYS = 29.530588;
+
+/** Major window: peak ±60 min. Minor window: peak ±45 min. */
+const MAJOR_HALF_MS = 60 * MINUTE_MS;
+const MINOR_HALF_MS = 45 * MINUTE_MS;
+/** Twilight overlap window: sunrise/sunset ±30 min. */
+const TWILIGHT_HALF_MS = 30 * MINUTE_MS;
+
+const MOON_PHASE_NAMES = [
+  "New Moon",
+  "Waxing Crescent",
+  "First Quarter",
+  "Waxing Gibbous",
+  "Full Moon",
+  "Waning Gibbous",
+  "Last Quarter",
+  "Waning Crescent",
+] as const;
+
+function moonPhaseName(phase: number): string {
+  const normalized = ((phase % 1) + 1) % 1;
+  const index = Math.round(normalized * 8) % 8;
+  return MOON_PHASE_NAMES[index];
+}
+
+/** Offset of `timeZone` from UTC at `date`, in minutes (east positive). */
+export function tzOffsetMinutes(date: Date, timeZone: string): number {
+  const dtf = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    hour12: false,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+  const parts: Record<string, string> = {};
+  for (const part of dtf.formatToParts(date)) parts[part.type] = part.value;
+  const asUtc = Date.UTC(
+    Number(parts.year),
+    Number(parts.month) - 1,
+    Number(parts.day),
+    Number(parts.hour) % 24,
+    Number(parts.minute),
+    Number(parts.second),
+  );
+  return Math.round((asUtc - date.getTime()) / MINUTE_MS);
+}
+
+/**
+ * UTC instant of local midnight opening the given calendar date.
+ * With an IANA zone the offset is resolved exactly (two passes handle DST
+ * transitions); without one the offset is approximated from longitude
+ * (15° per hour) — the convention printed solunar tables use.
+ */
+export function localDayStart(
+  date: string,
+  longitude: number,
+  timeZone?: string,
+): { startMs: number; basis: string } {
+  const naiveUtcMidnight = Date.parse(`${date}T00:00:00Z`);
+  if (Number.isNaN(naiveUtcMidnight)) {
+    throw new Error(`Invalid date "${date}". Use YYYY-MM-DD format.`);
+  }
+  if (timeZone) {
+    let offset = tzOffsetMinutes(new Date(naiveUtcMidnight), timeZone);
+    let startMs = naiveUtcMidnight - offset * MINUTE_MS;
+    // Re-resolve once in case midnight sits across a DST transition.
+    offset = tzOffsetMinutes(new Date(startMs), timeZone);
+    startMs = naiveUtcMidnight - offset * MINUTE_MS;
+    return { startMs, basis: timeZone };
+  }
+  const offsetHours = Math.round(longitude / 15);
+  return {
+    startMs: naiveUtcMidnight - offsetHours * HOUR_MS,
+    basis: `UTC${offsetHours >= 0 ? "+" : ""}${offsetHours} (from longitude)`,
+  };
+}
+
+/**
+ * Lunar transits within [startMs, startMs + 24h): scan altitude at 1-minute
+ * steps and keep interior local extrema. One-minute resolution is well within
+ * the precision solunar windows carry.
+ */
+export function findMoonTransits(
+  startMs: number,
+  latitude: number,
+  longitude: number,
+): { overhead: Date | null; underfoot: Date | null } {
+  const steps = DAY_MS / MINUTE_MS;
+  let prev = SunCalc.getMoonPosition(
+    new Date(startMs - MINUTE_MS),
+    latitude,
+    longitude,
+  ).altitude;
+  let curr = SunCalc.getMoonPosition(
+    new Date(startMs),
+    latitude,
+    longitude,
+  ).altitude;
+  let overhead: Date | null = null;
+  let underfoot: Date | null = null;
+  for (let i = 0; i < steps; i++) {
+    const tNext = startMs + (i + 1) * MINUTE_MS;
+    const next = SunCalc.getMoonPosition(
+      new Date(tNext),
+      latitude,
+      longitude,
+    ).altitude;
+    if (curr > prev && curr >= next && overhead === null) {
+      overhead = new Date(startMs + i * MINUTE_MS);
+    } else if (curr < prev && curr <= next && underfoot === null) {
+      underfoot = new Date(startMs + i * MINUTE_MS);
+    }
+    prev = curr;
+    curr = next;
+  }
+  return { overhead, underfoot };
+}
+
+function within(t: number, center: number, halfWidth: number): boolean {
+  return Math.abs(t - center) <= halfWidth;
+}
+
+function overlaps(
+  aStart: number,
+  aEnd: number,
+  bStart: number,
+  bEnd: number,
+): boolean {
+  return aStart <= bEnd && bStart <= aEnd;
+}
+
+function ratingLabel(rating: number): SolunarDay["rating_label"] {
+  if (rating >= 80) return "Excellent";
+  if (rating >= 60) return "Very Good";
+  if (rating >= 40) return "Good";
+  if (rating >= 20) return "Fair";
+  return "Poor";
+}
+
+export interface SolunarParams {
+  date?: string;
+  latitude: number;
+  longitude: number;
+  /** IANA zone for day boundaries and local rendering; else derived from longitude. */
+  timezone?: string;
+}
+
+export class SolunarService {
+  getSolunarDay(params: SolunarParams): SolunarDay {
+    const date = params.date ?? new Date().toISOString().split("T")[0];
+    const { latitude, longitude } = params;
+    const { startMs, basis } = localDayStart(date, longitude, params.timezone);
+    const endMs = startMs + DAY_MS;
+    const noon = new Date(startMs + DAY_MS / 2);
+
+    // --- Lunar events for the local day -----------------------------------
+    const { overhead, underfoot } = findMoonTransits(
+      startMs,
+      latitude,
+      longitude,
+    );
+    // suncalc's getMoonTimes works on the UTC day of the passed date when
+    // inUTC=true; pass the local day start so rise/set land inside our day.
+    const moonTimes = SunCalc.getMoonTimes(
+      new Date(startMs),
+      latitude,
+      longitude,
+      true,
+    );
+    const inDay = (d: Date | null | undefined): Date | null =>
+      d &&
+      !Number.isNaN(d.getTime()) &&
+      d.getTime() >= startMs &&
+      d.getTime() < endMs
+        ? d
+        : null;
+    const moonrise = inDay(moonTimes.rise);
+    const moonset = inDay(moonTimes.set);
+
+    const sunTimes = SunCalc.getTimes(noon, latitude, longitude);
+    const sunrise =
+      sunTimes.sunrise && !Number.isNaN(sunTimes.sunrise.getTime())
+        ? sunTimes.sunrise
+        : null;
+    const sunset =
+      sunTimes.sunset && !Number.isNaN(sunTimes.sunset.getTime())
+        ? sunTimes.sunset
+        : null;
+
+    const illumination = SunCalc.getMoonIllumination(noon);
+    const moonPosition = SunCalc.getMoonPosition(noon, latitude, longitude);
+
+    // --- Periods -----------------------------------------------------------
+    const twilights: Array<[number, number]> = [];
+    if (sunrise)
+      twilights.push([
+        sunrise.getTime() - TWILIGHT_HALF_MS,
+        sunrise.getTime() + TWILIGHT_HALF_MS,
+      ]);
+    if (sunset)
+      twilights.push([
+        sunset.getTime() - TWILIGHT_HALF_MS,
+        sunset.getTime() + TWILIGHT_HALF_MS,
+      ]);
+
+    const buildPeriod = (
+      kind: SolunarPeriod["kind"],
+      event: SolunarPeriod["event"],
+      peak: Date | null,
+    ): SolunarPeriod | null => {
+      if (!peak) return null;
+      const half = kind === "major" ? MAJOR_HALF_MS : MINOR_HALF_MS;
+      const startT = peak.getTime() - half;
+      const endT = peak.getTime() + half;
+      return {
+        kind,
+        event,
+        start: new Date(startT).toISOString(),
+        peak: peak.toISOString(),
+        end: new Date(endT).toISOString(),
+        overlaps_twilight: twilights.some(([a, b]) =>
+          overlaps(startT, endT, a, b),
+        ),
+      };
+    };
+
+    const periods = [
+      buildPeriod("major", "moon_overhead", overhead),
+      buildPeriod("major", "moon_underfoot", underfoot),
+      buildPeriod("minor", "moonrise", moonrise),
+      buildPeriod("minor", "moonset", moonset),
+    ]
+      .filter((p): p is SolunarPeriod => p !== null)
+      .sort((a, b) => a.peak.localeCompare(b.peak));
+
+    // --- Day rating --------------------------------------------------------
+    const factors: SolunarRatingFactor[] = [];
+
+    // Moon phase: distance (in days) to the nearest syzygy (new or full).
+    const age = illumination.phase * LUNAR_MONTH_DAYS;
+    const daysFromSyzygy = Math.min(
+      Math.abs(illumination.phase - 0) * LUNAR_MONTH_DAYS,
+      Math.abs(illumination.phase - 0.5) * LUNAR_MONTH_DAYS,
+      Math.abs(illumination.phase - 1) * LUNAR_MONTH_DAYS,
+    );
+    const phasePoints = Math.round(40 * Math.max(0, 1 - daysFromSyzygy / 5));
+    factors.push({
+      factor: "moon_phase",
+      points: phasePoints,
+      max_points: 40,
+      detail: `${moonPhaseName(illumination.phase)} — ${daysFromSyzygy.toFixed(1)} days from new/full moon (closer is better; syzygy also drives spring tides).`,
+    });
+
+    // Moon distance: perigee (~356,500 km) scores full, apogee (~406,700 km) zero.
+    const distancePoints = Math.round(
+      20 *
+        Math.min(
+          1,
+          Math.max(0, (406_700 - moonPosition.distance) / (406_700 - 356_500)),
+        ),
+    );
+    factors.push({
+      factor: "moon_distance",
+      points: distancePoints,
+      max_points: 20,
+      detail: `${Math.round(moonPosition.distance).toLocaleString()} km — nearer perigee means stronger tidal pull.`,
+    });
+
+    // Twilight overlap: any solunar window touching dawn or dusk.
+    const overlapCount = periods.filter((p) => p.overlaps_twilight).length;
+    const overlapPoints = Math.min(25, overlapCount * 13);
+    factors.push({
+      factor: "twilight_overlap",
+      points: overlapPoints,
+      max_points: 25,
+      detail:
+        overlapCount > 0
+          ? `${overlapCount} solunar period(s) overlap dawn/dusk — stacked feeding triggers.`
+          : "No solunar period overlaps dawn or dusk today.",
+    });
+
+    // Period completeness: both transits and both rise/set present.
+    const majorCount = periods.filter((p) => p.kind === "major").length;
+    const minorCount = periods.length - majorCount;
+    const completenessPoints = majorCount * 5 + minorCount * 2.5;
+    factors.push({
+      factor: "period_count",
+      points: Math.round(completenessPoints),
+      max_points: 15,
+      detail: `${majorCount} major and ${minorCount} minor period(s) fall within this day.`,
+    });
+
+    const rating = Math.max(
+      0,
+      Math.min(
+        100,
+        Math.round(
+          phasePoints + distancePoints + overlapPoints + completenessPoints,
+        ),
+      ),
+    );
+
+    // --- Activity curve (48 half-hour samples) -----------------------------
+    // Cosine bumps centered on each peak; majors carry twice the weight of
+    // minors; scaled so a strong day fills more of the 0-100 range.
+    const dayScale = 0.5 + rating / 200; // 0.5–1.0
+    const hourly_activity: SolunarDay["hourly_activity"] = [];
+    for (let i = 0; i < 48; i++) {
+      const t = startMs + i * 30 * MINUTE_MS;
+      let activity = 0;
+      for (const p of periods) {
+        const half = p.kind === "major" ? MAJOR_HALF_MS : MINOR_HALF_MS;
+        const weight = p.kind === "major" ? 100 : 55;
+        const dt = Math.abs(t - Date.parse(p.peak));
+        if (dt <= half) {
+          activity += weight * (0.5 + 0.5 * Math.cos((Math.PI * dt) / half));
+        }
+      }
+      for (const [a, b] of twilights) {
+        const center = (a + b) / 2;
+        if (within(t, center, HOUR_MS)) {
+          activity +=
+            20 * (0.5 + 0.5 * Math.cos((Math.PI * (t - center)) / HOUR_MS));
+        }
+      }
+      hourly_activity.push({
+        time: new Date(t).toISOString(),
+        activity: Math.round(Math.min(100, activity * dayScale)),
+      });
+    }
+
+    const iso = (d: Date | null): string | null => (d ? d.toISOString() : null);
+
+    return {
+      date,
+      latitude,
+      longitude,
+      time_basis: basis,
+      moon_phase: moonPhaseName(illumination.phase),
+      moon_illumination: Math.round(illumination.fraction * 1000) / 1000,
+      moon_age_days: Math.round(age * 10) / 10,
+      moon_distance_km: Math.round(moonPosition.distance),
+      moonrise: iso(moonrise),
+      moonset: iso(moonset),
+      moon_overhead: iso(overhead),
+      moon_underfoot: iso(underfoot),
+      sunrise: iso(sunrise),
+      sunset: iso(sunset),
+      periods,
+      rating,
+      rating_label: ratingLabel(rating),
+      rating_factors: factors,
+      hourly_activity,
+    };
+  }
+
+  getSolunarRange(
+    params: SolunarParams & { start_date: string; end_date: string },
+  ): SolunarDay[] {
+    const start = Date.parse(`${params.start_date}T00:00:00Z`);
+    const end = Date.parse(`${params.end_date}T00:00:00Z`);
+    if (Number.isNaN(start) || Number.isNaN(end)) {
+      throw new Error("Invalid date format. Please use YYYY-MM-DD format.");
+    }
+    if (start > end) {
+      throw new Error("Start date must be before end date.");
+    }
+    const days = Math.round((end - start) / DAY_MS) + 1;
+    if (days > 14) {
+      throw new Error(
+        "Solunar range is limited to 14 days per request — narrow the window.",
+      );
+    }
+    const out: SolunarDay[] = [];
+    for (let i = 0; i < days; i++) {
+      const date = new Date(start + i * DAY_MS).toISOString().split("T")[0];
+      out.push(
+        this.getSolunarDay({
+          date,
+          latitude: params.latitude,
+          longitude: params.longitude,
+          timezone: params.timezone,
+        }),
+      );
+    }
+    return out;
+  }
+}

--- a/src/tools/buoys.ts
+++ b/src/tools/buoys.ts
@@ -1,0 +1,276 @@
+/**
+ * NDBC buoy tools: find offshore buoys near a point and read their realtime
+ * observations — observed waves, water temperature, wind, and the 3-hour
+ * pressure tendency anglers use to time fronts. Complements CO-OPS coastal
+ * stations (which rarely carry wave or offshore water-temp sensors).
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerAppTool } from "@modelcontextprotocol/ext-apps/server";
+import { z } from "zod";
+import { CHARTS_UI_URI } from "../ui/app-resource.js";
+import {
+  findNearestBuoys,
+  getBuoyObservations,
+  NdbcObservation,
+} from "../services/ndbc.js";
+import {
+  LatitudeSchema,
+  LongitudeSchema,
+  READ_ONLY_ANNOTATIONS,
+  ResponseFormatSchema,
+  UnitsSchema,
+} from "../schemas/common.js";
+import { markdownTable, respond, respondError } from "../format/respond.js";
+import { seriesMarkdown } from "../format/series.js";
+
+const BuoyIdSchema = z
+  .string()
+  .regex(
+    /^[A-Za-z0-9]{4,6}$/,
+    'NDBC IDs are 5-digit numbers for moored buoys (e.g. "41013") or alphanumeric codes for coastal/C-MAN stations (e.g. "BUZM3").',
+  )
+  .describe(
+    'NDBC station ID (e.g. "41013", "BUZM3") — distinct from CO-OPS station IDs. Find one with ndbc_find_nearest_buoys.',
+  );
+
+const MS_TO_KNOTS = 1.9438444924;
+const M_TO_FT = 3.28084;
+
+function cToF(c: number): number {
+  return (c * 9) / 5 + 32;
+}
+
+function round1(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+interface DisplayObservation {
+  time: string;
+  wind_dir_deg: number | null;
+  wind_speed: number | null;
+  wind_gust: number | null;
+  wave_height: number | null;
+  dominant_period_s: number | null;
+  average_period_s: number | null;
+  mean_wave_dir_deg: number | null;
+  pressure_mb: number | null;
+  pressure_tendency_mb: number | null;
+  air_temp: number | null;
+  water_temp: number | null;
+  dewpoint: number | null;
+}
+
+/** Convert NDBC's fixed metric units to the requested display system. */
+export function toDisplayUnits(
+  obs: NdbcObservation,
+  units: "english" | "metric",
+): DisplayObservation {
+  const english = units === "english";
+  const speed = (v: number | null) =>
+    v === null ? null : round1(english ? v * MS_TO_KNOTS : v);
+  const length = (v: number | null) =>
+    v === null ? null : round1(english ? v * M_TO_FT : v);
+  const temp = (v: number | null) =>
+    v === null ? null : round1(english ? cToF(v) : v);
+  return {
+    time: obs.time,
+    wind_dir_deg: obs.wind_dir_deg,
+    wind_speed: speed(obs.wind_speed_ms),
+    wind_gust: speed(obs.wind_gust_ms),
+    wave_height: length(obs.wave_height_m),
+    dominant_period_s: obs.dominant_period_s,
+    average_period_s: obs.average_period_s,
+    mean_wave_dir_deg: obs.mean_wave_dir_deg,
+    pressure_mb: obs.pressure_hpa,
+    pressure_tendency_mb: obs.pressure_tendency_hpa,
+    air_temp: temp(obs.air_temp_c),
+    water_temp: temp(obs.water_temp_c),
+    dewpoint: temp(obs.dewpoint_c),
+  };
+}
+
+export function registerBuoyTools(server: McpServer): void {
+  server.registerTool(
+    "ndbc_find_nearest_buoys",
+    {
+      title: "Find Nearest NDBC Buoys",
+      description: `Find active NOAA NDBC buoys and coastal (C-MAN) stations nearest a latitude/longitude, sorted by great-circle distance. NDBC stations report what CO-OPS tide stations usually don't: offshore wave height/period/direction, sea-surface temperature, and open-water wind.
+
+NDBC IDs (e.g. "41013", "BUZM3") are a separate namespace from CO-OPS station IDs — use them only with ndbc_get_buoy_observations.`,
+      inputSchema: {
+        latitude: LatitudeSchema,
+        longitude: LongitudeSchema,
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(50)
+          .default(10)
+          .describe("Maximum stations to return."),
+        max_distance_km: z
+          .number()
+          .positive()
+          .optional()
+          .describe("Only include stations within this distance."),
+        require_met: z
+          .boolean()
+          .default(false)
+          .describe(
+            "Only stations currently reporting standard meteorology (wind/pressure/temps). Note: some wave-only buoys report waves but not met.",
+          ),
+        response_format: ResponseFormatSchema,
+      },
+      annotations: READ_ONLY_ANNOTATIONS,
+    },
+    async (params) => {
+      try {
+        const stations = await findNearestBuoys(
+          params.latitude,
+          params.longitude,
+          params.limit,
+          {
+            requireMet: params.require_met,
+            maxDistanceKm: params.max_distance_km,
+          },
+        );
+        const structured = {
+          count: stations.length,
+          stations: stations.map((s) => ({
+            ...s,
+            distance_km: round1(s.distance_km),
+            distance_mi: round1(s.distance_mi),
+          })),
+        };
+        const markdown = [
+          `# Nearest NDBC Buoys to (${params.latitude}, ${params.longitude})`,
+          "",
+          stations.length === 0
+            ? "_No active NDBC stations matched. Try removing max_distance_km or require_met._"
+            : markdownTable(
+                [
+                  "ID",
+                  "Name",
+                  "Type",
+                  "Distance (km)",
+                  "Distance (mi)",
+                  "Met",
+                  "Currents",
+                ],
+                stations.map((s) => [
+                  s.id,
+                  s.name,
+                  s.type,
+                  s.distance_km.toFixed(1),
+                  s.distance_mi.toFixed(1),
+                  s.has_met ? "yes" : "no",
+                  s.has_currents ? "yes" : "no",
+                ]),
+              ),
+          "",
+          "_Read a station's data with ndbc_get_buoy_observations. Wave sensors are common on 5-digit moored buoys; C-MAN shore stations usually report met only._",
+        ].join("\n");
+        return respond(params.response_format, structured, markdown);
+      } catch (error) {
+        return respondError(error);
+      }
+    },
+  );
+
+  registerAppTool(
+    server,
+    "ndbc_get_buoy_observations",
+    {
+      title: "Get NDBC Buoy Observations",
+      description: `Realtime observations from an NDBC buoy or C-MAN station, newest first: wind (direction/speed/gust), waves (significant height, dominant and average period, direction), sea-level pressure with 3-hour tendency (PTDY — falling pressure often precedes a feeding window, a sharp post-frontal rise often shuts fishing down), air/water temperature, and dewpoint.
+
+NDBC publishes the last ~45 days at 10-60 minute cadence. Fields a station doesn't sense are null.`,
+      inputSchema: {
+        buoy_id: BuoyIdSchema,
+        hours: z
+          .number()
+          .int()
+          .min(1)
+          .max(1080)
+          .default(24)
+          .describe("How many hours back from now to return (max 45 days)."),
+        units: UnitsSchema,
+        response_format: ResponseFormatSchema,
+      },
+      annotations: READ_ONLY_ANNOTATIONS,
+      _meta: { ui: { resourceUri: CHARTS_UI_URI } },
+    },
+    async (params) => {
+      try {
+        const result = await getBuoyObservations(params.buoy_id, params.hours);
+        const display = result.observations.map((o) =>
+          toDisplayUnits(o, params.units),
+        );
+        const english = params.units === "english";
+        const speedUnit = english ? "kt" : "m/s";
+        const lengthUnit = english ? "ft" : "m";
+        const tempUnit = english ? "°F" : "°C";
+        const structured = {
+          viz: { kind: "buoy_obs" },
+          station_id: result.station_id,
+          station: result.station,
+          units: params.units,
+          unit_labels: {
+            wind: speedUnit,
+            waves: lengthUnit,
+            temperature: tempUnit,
+            pressure: "mb",
+            wave_period: "s",
+          },
+          count: display.length,
+          observations: display,
+        };
+        // Keep the table readable: cap markdown rows, full series in JSON.
+        const rows = display.slice(0, 48);
+        const markdown = seriesMarkdown(
+          {
+            title: "NDBC Buoy Observations",
+            station: result.station_id,
+            stationName: result.station?.name,
+            unitsLabel: `wind ${speedUnit} · waves ${lengthUnit} · temps ${tempUnit} · pressure mb`,
+            timeZone: "UTC",
+            extra:
+              display.length > rows.length
+                ? [
+                    `_Showing newest ${rows.length} of ${display.length} records; the JSON payload carries all of them._`,
+                  ]
+                : undefined,
+          },
+          [
+            "Time (UTC)",
+            "Wind dir",
+            `Wind (${speedUnit})`,
+            `Gust (${speedUnit})`,
+            `Waves (${lengthUnit})`,
+            "Dom period (s)",
+            `Water (${tempUnit})`,
+            `Air (${tempUnit})`,
+            "Pressure (mb)",
+            "3h Δ (mb)",
+          ],
+          rows.map((o) => [
+            o.time.replace(".000Z", "Z"),
+            o.wind_dir_deg,
+            o.wind_speed,
+            o.wind_gust,
+            o.wave_height,
+            o.dominant_period_s,
+            o.water_temp,
+            o.air_temp,
+            o.pressure_mb,
+            o.pressure_tendency_mb,
+          ]),
+          "PTDY (3h Δ): falling = approaching low/front; rising = clearing high.",
+        );
+        return respond(params.response_format, structured, markdown);
+      } catch (error) {
+        return respondError(error);
+      }
+    },
+  );
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -12,8 +12,14 @@ import { registerDerivedProductTools } from "./derived.js";
 import { registerAstronomyTools } from "./astronomy.js";
 import { registerMarineForecastTools } from "./marine-forecast.js";
 import { registerReferenceTools } from "./reference.js";
+import { registerSolunarTools } from "./solunar.js";
+import { registerBuoyTools } from "./buoys.js";
+import { registerMarineConditionsTools } from "./marine-conditions.js";
+import { registerChartsUiResource } from "../ui/app-resource.js";
 
 export function registerAllTools(server: McpServer): void {
+  // The shared MCP-app template must exist before app tools reference it.
+  registerChartsUiResource(server);
   registerWaterTools(server);
   registerCurrentTools(server);
   registerMetTools(server);
@@ -21,6 +27,9 @@ export function registerAllTools(server: McpServer): void {
   registerStationMetadataTools(server);
   registerDerivedProductTools(server);
   registerAstronomyTools(server);
+  registerSolunarTools(server);
+  registerBuoyTools(server);
   registerMarineForecastTools(server);
+  registerMarineConditionsTools(server);
   registerReferenceTools(server);
 }

--- a/src/tools/marine-conditions.ts
+++ b/src/tools/marine-conditions.ts
@@ -1,0 +1,170 @@
+/**
+ * Open-Meteo Marine model forecast tool — wave/swell/SST/surface currents for
+ * ANY ocean coordinate ("virtual buoy"), where NWS gridpoints stop at US
+ * waters and NDBC only covers real buoys. Model output, not observations.
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerAppTool } from "@modelcontextprotocol/ext-apps/server";
+import { z } from "zod";
+import {
+  getMarineForecast,
+  MarineHourlySample,
+} from "../services/open-meteo.js";
+import {
+  LatitudeSchema,
+  LongitudeSchema,
+  READ_ONLY_ANNOTATIONS,
+  ResponseFormatSchema,
+  UnitsSchema,
+} from "../schemas/common.js";
+import { markdownTable, respond, respondError } from "../format/respond.js";
+import { CHARTS_UI_URI } from "../ui/app-resource.js";
+
+const M_TO_FT = 3.28084;
+const KMH_TO_KNOTS = 0.539957;
+const KMH_TO_CMS = 27.77778;
+
+function round1(v: number): number {
+  return Math.round(v * 10) / 10;
+}
+
+interface DisplaySample {
+  time: string;
+  wave_height: number | null;
+  wave_direction_deg: number | null;
+  wave_period_s: number | null;
+  wind_wave_height: number | null;
+  swell_height: number | null;
+  swell_direction_deg: number | null;
+  swell_period_s: number | null;
+  sea_surface_temp: number | null;
+  current_speed: number | null;
+  current_direction_deg: number | null;
+}
+
+/** Convert Open-Meteo native units (m, °C, km/h) to the display system. */
+export function toDisplaySample(
+  s: MarineHourlySample,
+  units: "english" | "metric",
+): DisplaySample {
+  const english = units === "english";
+  const length = (v: number | null) =>
+    v === null ? null : round1(english ? v * M_TO_FT : v);
+  const temp = (v: number | null) =>
+    v === null ? null : round1(english ? (v * 9) / 5 + 32 : v);
+  // Repo convention: currents are knots (english) or cm/s (metric).
+  const current = (v: number | null) =>
+    v === null ? null : round1(english ? v * KMH_TO_KNOTS : v * KMH_TO_CMS);
+  return {
+    time: s.time,
+    wave_height: length(s.wave_height_m),
+    wave_direction_deg: s.wave_direction_deg,
+    wave_period_s: s.wave_period_s,
+    wind_wave_height: length(s.wind_wave_height_m),
+    swell_height: length(s.swell_wave_height_m),
+    swell_direction_deg: s.swell_wave_direction_deg,
+    swell_period_s: s.swell_wave_period_s,
+    sea_surface_temp: temp(s.sea_surface_temp_c),
+    current_speed: current(s.current_velocity_kmh),
+    current_direction_deg: s.current_direction_deg,
+  };
+}
+
+export function registerMarineConditionsTools(server: McpServer): void {
+  registerAppTool(
+    server,
+    "openmeteo_get_marine_forecast",
+    {
+      title: "Get Marine Model Forecast (Waves, Swell, SST, Currents)",
+      description: `Hourly MODEL forecast for any ocean coordinate worldwide — a "virtual buoy": combined significant wave height/direction/period, wind-wave vs swell components (separately), sea surface temperature, and surface current speed/direction. Up to 10 days.
+
+Data is Open-Meteo's blend of wave models (GFS-Wave, ECMWF WAM, ICON-Wave) — model output, NOT observations; cross-check a nearby real buoy with ndbc_get_buoy_observations when one exists. Coastal points snap to the nearest ocean model cell; inland points error. Attribution: open-meteo.com (CC BY 4.0, non-commercial tier).
+
+Fishing context: long-period swell (>10s) with low wind-wave means clean conditions; SST breaks concentrate bait and pelagics.`,
+      inputSchema: {
+        latitude: LatitudeSchema,
+        longitude: LongitudeSchema,
+        days: z
+          .number()
+          .int()
+          .min(1)
+          .max(10)
+          .default(3)
+          .describe("Forecast length in days (hourly resolution)."),
+        units: UnitsSchema,
+        response_format: ResponseFormatSchema,
+      },
+      annotations: READ_ONLY_ANNOTATIONS,
+      _meta: { ui: { resourceUri: CHARTS_UI_URI } },
+    },
+    async (params) => {
+      try {
+        const forecast = await getMarineForecast(
+          params.latitude,
+          params.longitude,
+          params.days,
+        );
+        const display = forecast.samples.map((s) =>
+          toDisplaySample(s, params.units),
+        );
+        const english = params.units === "english";
+        const lengthUnit = english ? "ft" : "m";
+        const tempUnit = english ? "°F" : "°C";
+        const currentUnit = english ? "kt" : "cm/s";
+        const structured = {
+          viz: { kind: "marine_forecast" },
+          latitude: forecast.latitude,
+          longitude: forecast.longitude,
+          source: "Open-Meteo Marine (model blend; not observations)",
+          units: params.units,
+          unit_labels: {
+            waves: lengthUnit,
+            temperature: tempUnit,
+            currents: currentUnit,
+            period: "s",
+          },
+          count: display.length,
+          hourly: display,
+        };
+        // Markdown shows every 3rd hour to stay readable; JSON carries all.
+        const rows = display.filter((_, i) => i % 3 === 0);
+        const markdown = [
+          `# Marine Model Forecast (${forecast.latitude}, ${forecast.longitude})`,
+          "",
+          `**Source**: Open-Meteo wave-model blend (forecast, not observations) · **Units**: waves ${lengthUnit}, temps ${tempUnit}, currents ${currentUnit} · **Records**: ${display.length} hourly (table shows every 3rd)`,
+          "",
+          markdownTable(
+            [
+              "Time (UTC)",
+              `Waves (${lengthUnit})`,
+              "Dir",
+              "Period (s)",
+              `Swell (${lengthUnit})`,
+              "Swell period (s)",
+              `SST (${tempUnit})`,
+              `Current (${currentUnit})`,
+            ],
+            rows.map((s) => [
+              s.time.slice(0, 16).replace("T", " "),
+              s.wave_height,
+              s.wave_direction_deg === null
+                ? null
+                : `${Math.round(s.wave_direction_deg)}°`,
+              s.wave_period_s,
+              s.swell_height,
+              s.swell_period_s,
+              s.sea_surface_temp,
+              s.current_speed,
+            ]),
+          ),
+          "",
+          "_Directions: waves/swell FROM, currents TOWARD (degrees true). Weather data by Open-Meteo.com (CC BY 4.0)._",
+        ].join("\n");
+        return respond(params.response_format, structured, markdown);
+      } catch (error) {
+        return respondError(error);
+      }
+    },
+  );
+}

--- a/src/tools/marine-forecast.ts
+++ b/src/tools/marine-forecast.ts
@@ -81,7 +81,11 @@ This is FORECAST data. For observed (measured) wind at a NOAA station right now,
         const convertSpeed = (knots: number | null) =>
           knots === null ? null : metric ? round1(knotsToMs(knots)) : knots;
         const convertWave = (meters: number | null) =>
-          meters === null ? null : metric ? meters : round1(metersToFeet(meters));
+          meters === null
+            ? null
+            : metric
+              ? meters
+              : round1(metersToFeet(meters));
 
         const data = forecast.samples.map((s) => ({
           time_utc: s.time,

--- a/src/tools/met.ts
+++ b/src/tools/met.ts
@@ -32,6 +32,57 @@ const MET_KIND: Record<MetProduct, MeasurementKind> = {
   salinity: "salinity",
 };
 
+/**
+ * Classify a 3-hour pressure delta (mb) into the angler-meaningful states
+ * bite-forecast apps use. Thresholds follow the common meteorological
+ * convention: ±0.5 mb/3h ≈ steady, ±2 mb/3h ≈ rapid.
+ */
+export function classifyPressureTrend(rate: number | null): {
+  state: string;
+  interpretation: string;
+} {
+  if (rate === null) {
+    return {
+      state: "unknown",
+      interpretation:
+        "Too little recent data to classify the trend — widen the window or try another station.",
+    };
+  }
+  if (rate <= -2) {
+    return {
+      state: "falling rapidly",
+      interpretation:
+        "Sharp fall — a front or low is approaching. Classic pre-frontal window: fish often feed aggressively before it arrives, then shut down as it passes.",
+    };
+  }
+  if (rate <= -0.5) {
+    return {
+      state: "falling",
+      interpretation:
+        "Falling barometer — deteriorating weather ahead. Feeding activity often picks up while the fall continues.",
+    };
+  }
+  if (rate < 0.5) {
+    return {
+      state: "steady",
+      interpretation:
+        "Steady pressure — stable conditions and predictable patterns. After ~2-3 stable days, expect normal feeding around tide changes and solunar windows.",
+    };
+  }
+  if (rate < 2) {
+    return {
+      state: "rising",
+      interpretation:
+        "Rising barometer — clearing weather. The first day after a front is often slow; fishing typically improves as the rise levels off.",
+    };
+  }
+  return {
+    state: "rising rapidly",
+    interpretation:
+      "Sharp post-frontal rise — bluebird high-pressure conditions. Often the toughest bite; fish deeper, slower, and around structure.",
+  };
+}
+
 export function registerMetTools(server: McpServer): void {
   server.registerTool(
     "noaa_get_meteorological_data",
@@ -122,6 +173,107 @@ Not every station has every sensor — check with noaa_get_station_info (expand 
           rows,
           legend,
         );
+        return respond(params.response_format, structured, markdown);
+      } catch (error) {
+        return respondError(error);
+      }
+    },
+  );
+
+  server.registerTool(
+    "noaa_get_pressure_trend",
+    {
+      title: "Get Barometric Pressure Trend (Fishing Conditions)",
+      description: `Classify the barometric pressure trajectory at a NOAA station into the angler-meaningful states the bite-forecast apps use: falling rapidly / falling / steady / rising / rising rapidly, from observed air_pressure over the last 6-72 hours.
+
+Returns the latest pressure plus 3h/6h/24h deltas (millibars) and a fishing interpretation: a falling barometer ahead of a front often triggers aggressive pre-frontal feeding; a sharp rise into a post-frontal high commonly shuts fishing down; long steady pressure means stable, predictable patterns.
+
+Requires a station with a barometric sensor (check noaa_get_station_info, expand ["sensors"]); offshore alternatives report PTDY via ndbc_get_buoy_observations.`,
+      inputSchema: {
+        station: StationIdSchema,
+        hours: z
+          .number()
+          .int()
+          .min(6)
+          .max(72)
+          .default(30)
+          .describe("Observation window ending now (hours back)."),
+        response_format: ResponseFormatSchema,
+      },
+      annotations: READ_ONLY_ANNOTATIONS,
+    },
+    async (params) => {
+      try {
+        const response = await getMeteorologicalData({
+          station: params.station,
+          product: "air_pressure",
+          interval: "6",
+          units: "metric", // pressure is millibars in both systems
+          time_zone: "gmt",
+          range: params.hours,
+        });
+        const samples = (response.data ?? [])
+          .map((d) => ({
+            t: d.t as string,
+            v: Number(d.v),
+          }))
+          .filter((d) => Number.isFinite(d.v));
+        if (samples.length < 2) {
+          throw new Error(
+            `Not enough air_pressure data at station ${params.station} in the last ${params.hours}h to compute a trend. The station may lack a barometric sensor — check noaa_get_station_info (expand ["sensors"]).`,
+          );
+        }
+        const latest = samples[samples.length - 1];
+        const latestMs = Date.parse(`${latest.t.replace(" ", "T")}Z`);
+        const deltaOver = (hoursBack: number): number | null => {
+          const target = latestMs - hoursBack * 3_600_000;
+          let best: { t: string; v: number } | undefined;
+          let bestDist = Infinity;
+          for (const s of samples) {
+            const dist = Math.abs(
+              Date.parse(`${s.t.replace(" ", "T")}Z`) - target,
+            );
+            if (dist < bestDist) {
+              bestDist = dist;
+              best = s;
+            }
+          }
+          // Reject when the nearest sample is over an hour off target.
+          if (!best || bestDist > 3_600_000) return null;
+          return Math.round((latest.v - best.v) * 10) / 10;
+        };
+        const d3 = deltaOver(3);
+        const d6 = deltaOver(6);
+        const d24 = params.hours >= 24 ? deltaOver(24) : null;
+
+        // Classification keys off the 3-hour delta.
+        const { state, interpretation } = classifyPressureTrend(d3);
+
+        const structured = {
+          station: params.station,
+          window_hours: params.hours,
+          latest_pressure_mb: latest.v,
+          latest_time_utc: latest.t,
+          delta_3h_mb: d3,
+          delta_6h_mb: d6,
+          delta_24h_mb: d24,
+          trend: state,
+          interpretation,
+          sample_count: samples.length,
+        };
+        const markdown = [
+          `# Barometric Pressure Trend — Station ${params.station}`,
+          "",
+          `**Latest**: ${latest.v} mb at ${latest.t} UTC`,
+          "",
+          `- **3h change**: ${d3 === null ? "—" : `${d3 > 0 ? "+" : ""}${d3} mb`}`,
+          `- **6h change**: ${d6 === null ? "—" : `${d6 > 0 ? "+" : ""}${d6} mb`}`,
+          `- **24h change**: ${d24 === null ? "—" : `${d24 > 0 ? "+" : ""}${d24} mb`}`,
+          "",
+          `**Trend**: ${state.toUpperCase()}`,
+          "",
+          interpretation,
+        ].join("\n");
         return respond(params.response_format, structured, markdown);
       } catch (error) {
         return respondError(error);

--- a/src/tools/solunar.ts
+++ b/src/tools/solunar.ts
@@ -1,0 +1,156 @@
+/**
+ * Solunar bite-time forecast tool (computed locally — no network).
+ * The angler-facing composite the big fishing apps lead with: major/minor
+ * feeding windows, a 0-100 day rating with its factors spelled out, and a
+ * half-hourly activity curve suitable for charting.
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerAppTool } from "@modelcontextprotocol/ext-apps/server";
+import { z } from "zod";
+import { CHARTS_UI_URI } from "../ui/app-resource.js";
+import { SolunarService, SolunarDay } from "../services/solunar-service.js";
+import {
+  LatitudeSchema,
+  LOCAL_COMPUTE_ANNOTATIONS,
+  LongitudeSchema,
+  ResponseFormatSchema,
+} from "../schemas/common.js";
+import { markdownTable, respond, respondError } from "../format/respond.js";
+
+const IsoDateSchema = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, "Use YYYY-MM-DD format.")
+  .describe("Date in YYYY-MM-DD format. Defaults to today.");
+
+const SPARK_BLOCKS = "▁▂▃▄▅▆▇█";
+
+/** Compact unicode sparkline of the 48-sample activity curve. */
+export function activitySparkline(day: SolunarDay): string {
+  return day.hourly_activity
+    .map((s) => {
+      const idx = Math.min(
+        SPARK_BLOCKS.length - 1,
+        Math.floor((s.activity / 100) * SPARK_BLOCKS.length),
+      );
+      return SPARK_BLOCKS[idx];
+    })
+    .join("");
+}
+
+function formatLocalHm(iso: string | null, timezone?: string): string {
+  if (!iso) return "—";
+  const date = new Date(iso);
+  if (timezone) {
+    try {
+      return date.toLocaleTimeString("en-US", {
+        timeZone: timezone,
+        hour: "2-digit",
+        minute: "2-digit",
+        hour12: false,
+      });
+    } catch {
+      // fall through to UTC
+    }
+  }
+  return `${iso.slice(11, 16)}Z`;
+}
+
+export function registerSolunarTools(server: McpServer): void {
+  const service = new SolunarService();
+
+  registerAppTool(
+    server,
+    "astro_get_solunar_forecast",
+    {
+      title: "Get Solunar Fishing Forecast",
+      description: `Solunar bite-time forecast for a location and date (or range up to 14 days): MAJOR feeding periods (~2h, centered on the moon crossing overhead/underfoot) and MINOR periods (~1.5h, centered on moonrise/moonset), plus a 0-100 day rating built from moon phase (new/full is best and also drives spring tides), moon-perigee distance, dawn/dusk overlap, and period count — each factor reported separately.
+
+Also returns a 48-point half-hourly activity curve (0-100) for charting. Computed locally from lunar/solar geometry (classic Knight solunar theory — a planning heuristic, not physics). Combine with real conditions: tides (noaa_get_tide_predictions), wind (nws_get_wind_forecast), and pressure trend.`,
+      inputSchema: {
+        latitude: LatitudeSchema,
+        longitude: LongitudeSchema,
+        date: IsoDateSchema.optional(),
+        end_date: IsoDateSchema.optional().describe(
+          "Optional range end (max 14 days from date): one forecast per day.",
+        ),
+        timezone: z
+          .string()
+          .optional()
+          .describe(
+            'IANA timezone (e.g. "America/New_York") for day boundaries and local times. Defaults to a fixed offset estimated from longitude.',
+          ),
+        response_format: ResponseFormatSchema,
+      },
+      annotations: LOCAL_COMPUTE_ANNOTATIONS,
+      _meta: { ui: { resourceUri: CHARTS_UI_URI } },
+    },
+    async (params) => {
+      try {
+        const days = params.end_date
+          ? service.getSolunarRange({
+              start_date: params.date ?? new Date().toISOString().split("T")[0],
+              end_date: params.end_date,
+              latitude: params.latitude,
+              longitude: params.longitude,
+              timezone: params.timezone,
+            })
+          : [
+              service.getSolunarDay({
+                date: params.date,
+                latitude: params.latitude,
+                longitude: params.longitude,
+                timezone: params.timezone,
+              }),
+            ];
+        const structured = {
+          viz: { kind: "solunar", timezone: params.timezone },
+          count: days.length,
+          days,
+        };
+
+        const lines: string[] = [
+          `# Solunar Fishing Forecast (${params.latitude}, ${params.longitude})`,
+          "",
+          `**Time basis**: ${days[0].time_basis} · times shown ${params.timezone ? `in ${params.timezone}` : "as UTC (HH:MMZ)"}`,
+        ];
+        for (const day of days) {
+          lines.push(
+            "",
+            `## ${day.date} — ${day.rating}/100 (${day.rating_label})`,
+            "",
+            `**Moon**: ${day.moon_phase}, ${(day.moon_illumination * 100).toFixed(0)}% lit, ${day.moon_distance_km.toLocaleString()} km · **Sun**: rise ${formatLocalHm(day.sunrise, params.timezone)}, set ${formatLocalHm(day.sunset, params.timezone)}`,
+            "",
+            markdownTable(
+              ["Period", "Event", "Start", "Peak", "End", "Dawn/dusk overlap"],
+              day.periods.map((p) => [
+                p.kind === "major" ? "MAJOR" : "minor",
+                p.event.replace(/_/g, " "),
+                formatLocalHm(p.start, params.timezone),
+                formatLocalHm(p.peak, params.timezone),
+                formatLocalHm(p.end, params.timezone),
+                p.overlaps_twilight ? "yes ✳" : "no",
+              ]),
+            ),
+            "",
+            `Activity (00→24h): \`${activitySparkline(day)}\``,
+            "",
+            day.rating_factors
+              .map(
+                (f) =>
+                  `- ${f.factor}: ${f.points}/${f.max_points} — ${f.detail}`,
+              )
+              .join("\n"),
+          );
+        }
+        lines.push(
+          "",
+          "_Solunar theory is a planning heuristic — weigh it against tide stage, wind, and barometric trend._",
+        );
+        return respond(params.response_format, structured, lines.join("\n"));
+      } catch (error) {
+        return respondError(error);
+      }
+    },
+  );
+}

--- a/src/tools/station-metadata.ts
+++ b/src/tools/station-metadata.ts
@@ -128,7 +128,10 @@ Use for: building custom tide computations, checking a station's dominant consti
         const amplitudeUnits =
           typeof payload.units === "string" && payload.units
             ? payload.units
-            : unitLabel(isCurrentStation ? "currents" : "water_level", params.units);
+            : unitLabel(
+                isCurrentStation ? "currents" : "water_level",
+                params.units,
+              );
         const structured = {
           station: params.station,
           bin: params.bin,

--- a/src/tools/water.ts
+++ b/src/tools/water.ts
@@ -3,6 +3,7 @@
  */
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerAppTool } from "@modelcontextprotocol/ext-apps/server";
 import { z } from "zod";
 import {
   getWaterLevels,
@@ -10,6 +11,7 @@ import {
   getTidePredictions,
   type DataApiResponse,
 } from "../services/data-api.js";
+import { CHARTS_UI_URI } from "../ui/app-resource.js";
 import {
   dateFields,
   DatumSchema,
@@ -241,11 +243,12 @@ Use for: historical extremes, mixed-tide analysis (HH vs H), long-term averages.
     },
   );
 
-  server.registerTool(
+  registerAppTool(
+    server,
     "noaa_get_tide_predictions",
     {
       title: "Get Tide Predictions",
-      description: `Get NOAA harmonic tide predictions (future or past) for a station.
+      description: `Get NOAA harmonic tide predictions (future or past) for a station. In MCP hosts that support Apps, this renders an interactive tide-curve chart.
 
 interval="hilo" (recommended for "when is high/low tide") returns the daily tide events with type H/L — up to 10 years per request. Other intervals (h, 1, 5, 6, 10, 15, 30, 60 minutes) return a height time series — up to 1 year per request.
 
@@ -268,6 +271,7 @@ Heights are relative to the requested datum (MLLW default). Notes:
         response_format: ResponseFormatSchema,
       },
       annotations: READ_ONLY_ANNOTATIONS,
+      _meta: { ui: { resourceUri: CHARTS_UI_URI } },
     },
     async (params) => {
       try {
@@ -275,6 +279,7 @@ Heights are relative to the requested datum (MLLW default). Notes:
         const data = response.predictions ?? [];
         const unitsLabel = `${unitLabel("water_level", params.units)} above ${params.datum}`;
         const structured = {
+          viz: { kind: "tide_curve" },
           station: params.station,
           product: "predictions",
           interval: params.interval,

--- a/src/ui/app-resource.ts
+++ b/src/ui/app-resource.ts
@@ -1,0 +1,81 @@
+/**
+ * MCP Apps (SEP-1865) UI resource: a single self-contained HTML template,
+ * "Perigee Charts", shared by every visualization-bearing tool. The template
+ * dispatches on `structuredContent.viz.kind` delivered via the standard
+ * ui/notifications/tool-result message, so one cached template serves every
+ * chart — hosts fetch it once and reuse it.
+ *
+ * The HTML is built by `scripts/build-ui.mjs` (esbuild bundle inlined into a
+ * shell page) into dist/ui/perigee-charts.html, next to this module's
+ * compiled output. It declares NO CSP metadata, which gives it the
+ * locked-down default sandbox (no network at all): all data arrives through
+ * the tool result, and all chart code is inlined.
+ *
+ * Hosts without the Apps extension simply never read ui:// resources and
+ * ignore `_meta.ui` on tools — the markdown + structuredContent responses
+ * remain the universal fallback.
+ */
+
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  registerAppResource,
+  RESOURCE_MIME_TYPE,
+} from "@modelcontextprotocol/ext-apps/server";
+
+export const CHARTS_UI_URI = "ui://perigee/charts.html";
+
+let templateCache: string | undefined;
+
+/**
+ * Locate the built template. Compiled layout puts it beside this module
+ * (dist/ui/); running from source with tsx falls back to dist/ui under cwd
+ * (requires a prior `npm run build`).
+ */
+async function loadTemplate(): Promise<string> {
+  if (templateCache) return templateCache;
+  const candidates = [
+    fileURLToPath(new URL("./perigee-charts.html", import.meta.url)),
+    resolve(process.cwd(), "dist/ui/perigee-charts.html"),
+  ];
+  for (const path of candidates) {
+    try {
+      templateCache = await readFile(path, "utf-8");
+      return templateCache;
+    } catch {
+      // try the next candidate
+    }
+  }
+  throw new Error(
+    "Perigee Charts UI template not found (dist/ui/perigee-charts.html). Run `npm run build` first.",
+  );
+}
+
+export function registerChartsUiResource(server: McpServer): void {
+  registerAppResource(
+    server,
+    "Perigee Charts",
+    CHARTS_UI_URI,
+    {
+      description:
+        "Interactive charts for tide predictions, solunar forecasts, buoy observations, and marine model forecasts.",
+      _meta: {
+        ui: {
+          // No csp entry: fully self-contained, zero-network sandbox.
+          prefersBorder: true,
+        },
+      },
+    },
+    async () => ({
+      contents: [
+        {
+          uri: CHARTS_UI_URI,
+          mimeType: RESOURCE_MIME_TYPE,
+          text: await loadTemplate(),
+        },
+      ],
+    }),
+  );
+}

--- a/tests/ndbc.test.ts
+++ b/tests/ndbc.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { parseActiveStations, parseRealtime2 } from "../src/services/ndbc.js";
+import { toDisplayUnits } from "../src/tools/buoys.js";
+import { toDisplaySample } from "../src/tools/marine-conditions.js";
+import { classifyPressureTrend } from "../src/tools/met.js";
+
+const ACTIVESTATIONS_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<stations created="2026-07-09T09:10:00UTC" count="3">
+<station id="41013" lat="33.441" lon="-77.764" elev="0" name="Frying Pan Shoals, NC" owner="NDBC" pgm="NDBC Meteorological/Ocean" type="buoy" met="y" currents="n" waterquality="n" dart="n"/>
+<station id="buzm3" lat="41.397" lon="-71.033" name="Buzzards Bay, MA &amp; environs" owner="NDBC" pgm="NDBC Meteorological/Ocean" type="fixed" met="y" currents="y" waterquality="n" dart="n"/>
+<station id="badrow" name="No coordinates" type="buoy"/>
+</stations>`;
+
+const REALTIME2_TEXT = `#YY  MM DD hh mm WDIR WSPD GST  WVHT   DPD   APD MWD   PRES  ATMP  WTMP  DEWP  VIS PTDY  TIDE
+#yr  mo dy hr mn degT m/s  m/s     m   sec   sec degT   hPa  degC  degC  degC  nmi  hPa    ft
+2026 07 09 14 50 140  5.0  6.5   1.2     7   5.4 145 1015.2  28.1  29.0  24.2   MM -1.6    MM
+2026 07 09 14 40 145  4.8   MM    MM    MM    MM  MM 1015.4  28.0  29.0    MM   MM   MM    MM
+`;
+
+describe("parseActiveStations", () => {
+  it("parses attributes, uppercases IDs, decodes entities, skips bad rows", () => {
+    const stations = parseActiveStations(ACTIVESTATIONS_XML);
+    expect(stations).toHaveLength(2);
+    const [buoy, cman] = stations;
+    expect(buoy.id).toBe("41013");
+    expect(buoy.lat).toBeCloseTo(33.441);
+    expect(buoy.type).toBe("buoy");
+    expect(buoy.has_met).toBe(true);
+    expect(buoy.has_currents).toBe(false);
+    expect(cman.id).toBe("BUZM3");
+    expect(cman.name).toBe("Buzzards Bay, MA & environs");
+    expect(cman.has_currents).toBe(true);
+  });
+});
+
+describe("parseRealtime2", () => {
+  it("maps columns by header name, nulls MM, keeps newest-first order", () => {
+    const obs = parseRealtime2(REALTIME2_TEXT);
+    expect(obs).toHaveLength(2);
+    const [newest, older] = obs;
+    expect(newest.time).toBe("2026-07-09T14:50:00.000Z");
+    expect(newest.wind_dir_deg).toBe(140);
+    expect(newest.wind_speed_ms).toBe(5);
+    expect(newest.wind_gust_ms).toBe(6.5);
+    expect(newest.wave_height_m).toBe(1.2);
+    expect(newest.dominant_period_s).toBe(7);
+    expect(newest.pressure_hpa).toBe(1015.2);
+    expect(newest.pressure_tendency_hpa).toBe(-1.6);
+    expect(newest.water_temp_c).toBe(29);
+    expect(newest.visibility_nmi).toBeNull();
+    expect(newest.tide_ft).toBeNull();
+    expect(older.wind_gust_ms).toBeNull();
+    expect(older.wave_height_m).toBeNull();
+  });
+
+  it("rejects files without a header", () => {
+    expect(() => parseRealtime2("not a realtime2 file")).toThrow(
+      /unexpected realtime2/,
+    );
+  });
+});
+
+describe("toDisplayUnits (NDBC)", () => {
+  const obs = parseRealtime2(REALTIME2_TEXT)[0];
+
+  it("converts to english units", () => {
+    const d = toDisplayUnits(obs, "english");
+    expect(d.wind_speed).toBeCloseTo(9.7, 1); // 5 m/s → kt
+    expect(d.wave_height).toBeCloseTo(3.9, 1); // 1.2 m → ft
+    expect(d.water_temp).toBeCloseTo(84.2, 1); // 29 °C → °F
+    expect(d.pressure_mb).toBe(1015.2); // millibars in both systems
+  });
+
+  it("passes metric through unchanged", () => {
+    const d = toDisplayUnits(obs, "metric");
+    expect(d.wind_speed).toBe(5);
+    expect(d.wave_height).toBe(1.2);
+    expect(d.water_temp).toBe(29);
+  });
+});
+
+describe("toDisplaySample (Open-Meteo)", () => {
+  const sample = {
+    time: "2026-07-09T14:00:00Z",
+    wave_height_m: 1.5,
+    wave_direction_deg: 120,
+    wave_period_s: 8.2,
+    wind_wave_height_m: 0.4,
+    wind_wave_period_s: 3.1,
+    swell_wave_height_m: 1.4,
+    swell_wave_direction_deg: 110,
+    swell_wave_period_s: 11,
+    sea_surface_temp_c: 26,
+    current_velocity_kmh: 1.8,
+    current_direction_deg: 45,
+  };
+
+  it("converts to english units (currents in knots)", () => {
+    const d = toDisplaySample(sample, "english");
+    expect(d.wave_height).toBeCloseTo(4.9, 1);
+    expect(d.sea_surface_temp).toBeCloseTo(78.8, 1);
+    expect(d.current_speed).toBeCloseTo(1, 1); // 1.8 km/h ≈ 0.97 kt
+  });
+
+  it("converts metric currents to cm/s (repo convention)", () => {
+    const d = toDisplaySample(sample, "metric");
+    expect(d.wave_height).toBe(1.5);
+    expect(d.current_speed).toBeCloseTo(50, 0); // 1.8 km/h = 50 cm/s
+  });
+});
+
+describe("classifyPressureTrend", () => {
+  it("classifies each band", () => {
+    expect(classifyPressureTrend(null).state).toBe("unknown");
+    expect(classifyPressureTrend(-3).state).toBe("falling rapidly");
+    expect(classifyPressureTrend(-1).state).toBe("falling");
+    expect(classifyPressureTrend(0).state).toBe("steady");
+    expect(classifyPressureTrend(1).state).toBe("rising");
+    expect(classifyPressureTrend(2.5).state).toBe("rising rapidly");
+  });
+});

--- a/tests/solunar.test.ts
+++ b/tests/solunar.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+import {
+  findMoonTransits,
+  localDayStart,
+  SolunarService,
+  tzOffsetMinutes,
+} from "../src/services/solunar-service.js";
+import { activitySparkline } from "../src/tools/solunar.js";
+
+const CAPE_COD = { latitude: 41.67, longitude: -70.2 };
+
+describe("localDayStart", () => {
+  it("resolves IANA-zone midnight to the right UTC instant (EDT)", () => {
+    const { startMs, basis } = localDayStart(
+      "2026-07-09",
+      CAPE_COD.longitude,
+      "America/New_York",
+    );
+    // 2026-07-09 is in daylight time: midnight local = 04:00Z.
+    expect(new Date(startMs).toISOString()).toBe("2026-07-09T04:00:00.000Z");
+    expect(basis).toBe("America/New_York");
+  });
+
+  it("falls back to a longitude-derived fixed offset", () => {
+    const { startMs, basis } = localDayStart("2026-07-09", -70.2);
+    // -70.2° / 15 ≈ -5 → midnight local = 05:00Z.
+    expect(new Date(startMs).toISOString()).toBe("2026-07-09T05:00:00.000Z");
+    expect(basis).toContain("UTC-5");
+  });
+
+  it("rejects malformed dates", () => {
+    expect(() => localDayStart("07/09/2026", 0)).toThrow(/Invalid date/);
+  });
+});
+
+describe("tzOffsetMinutes", () => {
+  it("matches known offsets across DST", () => {
+    expect(
+      tzOffsetMinutes(new Date("2026-07-09T12:00:00Z"), "America/New_York"),
+    ).toBe(-240);
+    expect(
+      tzOffsetMinutes(new Date("2026-01-09T12:00:00Z"), "America/New_York"),
+    ).toBe(-300);
+  });
+});
+
+describe("findMoonTransits", () => {
+  it("finds an overhead and underfoot transit ~12.4h apart", () => {
+    const dayStart = Date.parse("2026-07-09T04:00:00Z");
+    const { overhead, underfoot } = findMoonTransits(
+      dayStart,
+      CAPE_COD.latitude,
+      CAPE_COD.longitude,
+    );
+    // Both usually exist on any given day; require at least one and check
+    // spacing when both are present.
+    expect(overhead ?? underfoot).not.toBeNull();
+    if (overhead && underfoot) {
+      const gapHours =
+        Math.abs(overhead.getTime() - underfoot.getTime()) / 3_600_000;
+      expect(gapHours).toBeGreaterThan(10.5);
+      expect(gapHours).toBeLessThan(14.5);
+    }
+  });
+});
+
+describe("SolunarService", () => {
+  const service = new SolunarService();
+
+  it("produces a complete, internally consistent day forecast", () => {
+    const day = service.getSolunarDay({
+      date: "2026-07-09",
+      ...CAPE_COD,
+      timezone: "America/New_York",
+    });
+    expect(day.date).toBe("2026-07-09");
+    expect(day.rating).toBeGreaterThanOrEqual(0);
+    expect(day.rating).toBeLessThanOrEqual(100);
+    expect(day.hourly_activity).toHaveLength(48);
+    for (const sample of day.hourly_activity) {
+      expect(sample.activity).toBeGreaterThanOrEqual(0);
+      expect(sample.activity).toBeLessThanOrEqual(100);
+    }
+    // Rating factors add up to the rating (within rounding).
+    const sum = day.rating_factors.reduce((acc, f) => acc + f.points, 0);
+    expect(Math.abs(sum - day.rating)).toBeLessThanOrEqual(2);
+    // Periods are sorted and majors span 2h, minors 1.5h.
+    const peaks = day.periods.map((p) => p.peak);
+    expect([...peaks].sort()).toEqual(peaks);
+    for (const p of day.periods) {
+      const span = Date.parse(p.end) - Date.parse(p.start);
+      expect(span).toBe(p.kind === "major" ? 2 * 3_600_000 : 1.5 * 3_600_000);
+      const mid = (Date.parse(p.end) + Date.parse(p.start)) / 2;
+      expect(Math.abs(mid - Date.parse(p.peak))).toBeLessThan(1000);
+    }
+    // Every period peak falls inside the local day.
+    const dayStart = Date.parse("2026-07-09T04:00:00Z");
+    for (const p of day.periods) {
+      expect(Date.parse(p.peak)).toBeGreaterThanOrEqual(dayStart);
+      expect(Date.parse(p.peak)).toBeLessThan(dayStart + 24 * 3_600_000);
+    }
+  });
+
+  it("rates syzygy days above quarter-moon days", () => {
+    // 2026-06-24 ≈ full moon; 2026-07-01 ≈ first/last quarter week.
+    // Use phase distance directly: find within July 2026 the best and worst
+    // days and assert ordering is driven by the phase factor.
+    const range = service.getSolunarRange({
+      start_date: "2026-06-20",
+      end_date: "2026-07-03",
+      ...CAPE_COD,
+    });
+    const phasePoints = (d: (typeof range)[number]) =>
+      d.rating_factors.find((f) => f.factor === "moon_phase")!.points;
+    const newOrFull = range.filter(
+      (d) => d.moon_phase === "Full Moon" || d.moon_phase === "New Moon",
+    );
+    const quarters = range.filter(
+      (d) =>
+        d.moon_phase === "First Quarter" || d.moon_phase === "Last Quarter",
+    );
+    expect(newOrFull.length).toBeGreaterThan(0);
+    expect(quarters.length).toBeGreaterThan(0);
+    const minSyzygy = Math.min(...newOrFull.map(phasePoints));
+    const maxQuarter = Math.max(...quarters.map(phasePoints));
+    expect(minSyzygy).toBeGreaterThan(maxQuarter);
+  });
+
+  it("caps ranges at 14 days and validates order", () => {
+    expect(() =>
+      service.getSolunarRange({
+        start_date: "2026-07-01",
+        end_date: "2026-07-31",
+        ...CAPE_COD,
+      }),
+    ).toThrow(/14 days/);
+    expect(() =>
+      service.getSolunarRange({
+        start_date: "2026-07-09",
+        end_date: "2026-07-01",
+        ...CAPE_COD,
+      }),
+    ).toThrow(/before/);
+  });
+});
+
+describe("activitySparkline", () => {
+  it("renders one block per half-hour sample", () => {
+    const service = new SolunarService();
+    const day = service.getSolunarDay({ date: "2026-07-09", ...CAPE_COD });
+    const spark = activitySparkline(day);
+    expect([...spark]).toHaveLength(48);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,8 +8,9 @@
     "outDir": "./dist",
     "rootDir": "./src",
     "declaration": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "skipLibCheck": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "**/*.test.ts"]
-} 
+}

--- a/tsconfig.ui.json
+++ b/tsconfig.ui.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["ui/src/**/*.ts"]
+}

--- a/ui/src/chart.ts
+++ b/ui/src/chart.ts
@@ -1,0 +1,570 @@
+/**
+ * Minimal SVG chart core for the Perigee Charts MCP app.
+ *
+ * Hand-rolled instead of a chart library so the whole template stays a small
+ * self-contained file that renders inside the locked-down (no-network) MCP
+ * Apps sandbox. Follows the dataviz mark specs: 2px round-join lines, ~10%
+ * opacity area washes, hairline solid gridlines, recessive muted axis text,
+ * crosshair + single tooltip listing every series at the hovered X, markers
+ * with a surface ring. One y-axis per panel — multiple measures become
+ * stacked panels (small multiples) that share a crosshair.
+ */
+
+export interface Pt {
+  x: number;
+  y: number | null;
+}
+
+export interface Series {
+  label: string;
+  /** CSS variable name, e.g. "--s1". */
+  color: string;
+  points: Pt[];
+  /** Draw a ~10%-opacity wash under the line down to the panel floor. */
+  area?: boolean;
+  dashed?: boolean;
+  /** Format a value for tooltip/labels. */
+  fmt?: (v: number) => string;
+}
+
+export interface Band {
+  x0: number;
+  x1: number;
+  color: string;
+  label?: string;
+}
+
+export interface Marker {
+  x: number;
+  y: number;
+  color: string;
+  label?: string;
+  /** Optional second label line under the main one (e.g. a time). */
+  sub?: string;
+}
+
+export interface Panel {
+  title?: string;
+  unit?: string;
+  series: Series[];
+  bands?: Band[];
+  markers?: Marker[];
+  height?: number;
+  /** Fix the y domain (e.g. 0-100 for activity). */
+  yDomain?: [number, number];
+  /** Pad y domain to include zero baseline. */
+  includeZero?: boolean;
+}
+
+export interface ChartOptions {
+  /** Shared x domain (epoch ms). */
+  xDomain: [number, number];
+  panels: Panel[];
+  /** Format an x value for axis ticks. */
+  fmtX: (x: number) => string;
+  /** Format an x value for the tooltip header (more verbose). */
+  fmtXLong: (x: number) => string;
+  /** Draw a vertical "now" reference line at this x. */
+  now?: number;
+}
+
+const MARGIN = { top: 8, right: 12, bottom: 22, left: 46 };
+
+function el<K extends keyof SVGElementTagNameMap>(
+  name: K,
+  attrs: Record<string, string | number> = {},
+): SVGElementTagNameMap[K] {
+  const node = document.createElementNS("http://www.w3.org/2000/svg", name);
+  for (const [k, v] of Object.entries(attrs)) node.setAttribute(k, String(v));
+  return node;
+}
+
+function div(className: string): HTMLDivElement {
+  const node = document.createElement("div");
+  node.className = className;
+  return node;
+}
+
+/** Clean tick values for a numeric domain (1/2/5 steps). */
+export function niceTicks(min: number, max: number, count = 4): number[] {
+  if (!(max > min)) return [min];
+  const span = max - min;
+  const step0 = span / count;
+  const mag = Math.pow(10, Math.floor(Math.log10(step0)));
+  const candidates = [1, 2, 2.5, 5, 10].map((m) => m * mag);
+  const step = candidates.find((s) => span / s <= count + 0.5) ?? 10 * mag;
+  const start = Math.ceil(min / step) * step;
+  const ticks: number[] = [];
+  for (let v = start; v <= max + 1e-9; v += step) {
+    ticks.push(Math.round(v * 1e6) / 1e6);
+  }
+  return ticks;
+}
+
+/**
+ * Time ticks at clean hour/day boundaries for a UTC-ms domain. Domains over
+ * 36h get day-level labels (see makeFmtX in main.ts), so their step is
+ * forced to whole days to avoid repeating the same label.
+ */
+export function timeTicks(x0: number, x1: number, maxCount = 6): number[] {
+  const HOUR = 3_600_000;
+  const DAY = 24 * HOUR;
+  const spans =
+    x1 - x0 > 36 * HOUR
+      ? [DAY, 2 * DAY, 7 * DAY, 14 * DAY]
+      : [HOUR, 3 * HOUR, 6 * HOUR, 12 * HOUR, DAY];
+  const step =
+    spans.find((s) => (x1 - x0) / s <= maxCount) ?? spans[spans.length - 1];
+  const start = Math.ceil(x0 / step) * step;
+  const ticks: number[] = [];
+  for (let t = start; t <= x1; t += step) ticks.push(t);
+  return ticks;
+}
+
+interface PanelLayout {
+  panel: Panel;
+  svg: SVGSVGElement;
+  plotX: (x: number) => number;
+  plotY: (y: number) => number;
+  hoverLayer: SVGGElement;
+  width: number;
+  height: number;
+}
+
+export class Chart {
+  private layouts: PanelLayout[] = [];
+  private tooltip: HTMLDivElement;
+  private allX: number[] = [];
+
+  constructor(
+    private root: HTMLElement,
+    private opts: ChartOptions,
+  ) {
+    this.tooltip = div("pt-tooltip");
+    this.tooltip.style.display = "none";
+    this.render();
+  }
+
+  private render(): void {
+    this.root.textContent = "";
+    this.root.appendChild(this.tooltip);
+    this.layouts = [];
+
+    // Collect the union of x positions for crosshair snapping.
+    const xs = new Set<number>();
+    for (const panel of this.opts.panels) {
+      for (const s of panel.series) {
+        for (const p of s.points) xs.add(p.x);
+      }
+    }
+    this.allX = [...xs].sort((a, b) => a - b);
+
+    for (const panel of this.opts.panels) {
+      this.renderPanel(panel);
+    }
+
+    this.root.addEventListener("pointermove", (e) => this.onPointer(e));
+    this.root.addEventListener("pointerleave", () => this.clearHover());
+  }
+
+  private renderPanel(panel: Panel): void {
+    const card = div("pt-panel");
+    const width = Math.max(280, this.root.clientWidth || 640);
+    const height = panel.height ?? 150;
+
+    if (panel.title) {
+      const head = div("pt-panel-head");
+      const title = document.createElement("span");
+      title.className = "pt-panel-title";
+      title.textContent = panel.title;
+      head.appendChild(title);
+      if (panel.unit) {
+        const unit = document.createElement("span");
+        unit.className = "pt-panel-unit";
+        unit.textContent = panel.unit;
+        head.appendChild(unit);
+      }
+      if (panel.series.length > 1) {
+        const legend = div("pt-legend");
+        for (const s of panel.series) {
+          const item = div("pt-legend-item");
+          const key = document.createElement("span");
+          key.className = "pt-legend-key";
+          key.style.background = `var(${s.color})`;
+          item.appendChild(key);
+          const label = document.createElement("span");
+          label.textContent = s.label;
+          item.appendChild(label);
+          legend.appendChild(item);
+        }
+        head.appendChild(legend);
+      }
+      card.appendChild(head);
+    }
+
+    const svg = el("svg", {
+      width,
+      height,
+      viewBox: `0 0 ${width} ${height}`,
+      class: "pt-svg",
+    });
+    card.appendChild(svg);
+    this.root.appendChild(card);
+
+    const [x0, x1] = this.opts.xDomain;
+    let yMin = Infinity;
+    let yMax = -Infinity;
+    if (panel.yDomain) {
+      [yMin, yMax] = panel.yDomain;
+    } else {
+      for (const s of panel.series) {
+        for (const p of s.points) {
+          if (p.y === null || p.x < x0 || p.x > x1) continue;
+          if (p.y < yMin) yMin = p.y;
+          if (p.y > yMax) yMax = p.y;
+        }
+      }
+      for (const m of panel.markers ?? []) {
+        if (m.x < x0 || m.x > x1) continue;
+        if (m.y < yMin) yMin = m.y;
+        if (m.y > yMax) yMax = m.y;
+      }
+      if (!Number.isFinite(yMin)) {
+        yMin = 0;
+        yMax = 1;
+      }
+      if (panel.includeZero) yMin = Math.min(0, yMin);
+      const pad = (yMax - yMin || 1) * 0.12;
+      yMin -= pad;
+      yMax += pad;
+      if (panel.includeZero && yMin < 0 && yMin > -pad - 1e-9) yMin = 0;
+    }
+
+    const iw = width - MARGIN.left - MARGIN.right;
+    const ih = height - MARGIN.top - MARGIN.bottom;
+    const plotX = (x: number) => MARGIN.left + ((x - x0) / (x1 - x0)) * iw;
+    const plotY = (y: number) =>
+      MARGIN.top + ih - ((y - yMin) / (yMax - yMin || 1)) * ih;
+
+    // Bands first (under everything).
+    for (const band of panel.bands ?? []) {
+      const bx0 = Math.max(x0, band.x0);
+      const bx1 = Math.min(x1, band.x1);
+      if (bx1 <= bx0) continue;
+      svg.appendChild(
+        el("rect", {
+          x: plotX(bx0),
+          y: MARGIN.top,
+          width: plotX(bx1) - plotX(bx0),
+          height: ih,
+          fill: `var(${band.color})`,
+          opacity: 0.14,
+          rx: 2,
+        }),
+      );
+    }
+
+    // Gridlines + y ticks.
+    for (const tick of niceTicks(yMin, yMax)) {
+      const y = plotY(tick);
+      svg.appendChild(
+        el("line", {
+          x1: MARGIN.left,
+          x2: width - MARGIN.right,
+          y1: y,
+          y2: y,
+          class: "pt-grid",
+        }),
+      );
+      const label = el("text", {
+        x: MARGIN.left - 6,
+        y: y + 3,
+        class: "pt-tick pt-tick-y",
+        "text-anchor": "end",
+      });
+      label.textContent = formatTick(tick);
+      svg.appendChild(label);
+    }
+
+    // X ticks.
+    for (const tick of timeTicks(x0, x1)) {
+      const x = plotX(tick);
+      svg.appendChild(
+        el("line", {
+          x1: x,
+          x2: x,
+          y1: MARGIN.top + ih,
+          y2: MARGIN.top + ih + 3,
+          class: "pt-axis",
+        }),
+      );
+      const label = el("text", {
+        x,
+        y: height - 6,
+        class: "pt-tick",
+        "text-anchor": "middle",
+      });
+      label.textContent = this.opts.fmtX(tick);
+      svg.appendChild(label);
+    }
+
+    // Baseline.
+    svg.appendChild(
+      el("line", {
+        x1: MARGIN.left,
+        x2: width - MARGIN.right,
+        y1: MARGIN.top + ih,
+        y2: MARGIN.top + ih,
+        class: "pt-axis",
+      }),
+    );
+
+    // "Now" line.
+    if (
+      this.opts.now !== undefined &&
+      this.opts.now >= x0 &&
+      this.opts.now <= x1
+    ) {
+      const x = plotX(this.opts.now);
+      svg.appendChild(
+        el("line", {
+          x1: x,
+          x2: x,
+          y1: MARGIN.top,
+          y2: MARGIN.top + ih,
+          class: "pt-nowline",
+        }),
+      );
+    }
+
+    // Series: area washes, then lines.
+    for (const s of panel.series) {
+      const visible = s.points.filter((p) => p.x >= x0 && p.x <= x1);
+      const segments = splitSegments(visible);
+      if (s.area) {
+        for (const seg of segments) {
+          if (seg.length < 2) continue;
+          const dLine = seg
+            .map(
+              (p, i) =>
+                `${i === 0 ? "M" : "L"}${plotX(p.x).toFixed(1)},${plotY(p.y as number).toFixed(1)}`,
+            )
+            .join("");
+          const floor = MARGIN.top + ih;
+          const d = `${dLine}L${plotX(seg[seg.length - 1].x).toFixed(1)},${floor}L${plotX(seg[0].x).toFixed(1)},${floor}Z`;
+          svg.appendChild(
+            el("path", { d, fill: `var(${s.color})`, opacity: 0.1 }),
+          );
+        }
+      }
+      for (const seg of segments) {
+        if (seg.length === 0) continue;
+        if (seg.length === 1) {
+          svg.appendChild(
+            el("circle", {
+              cx: plotX(seg[0].x),
+              cy: plotY(seg[0].y as number),
+              r: 2.5,
+              fill: `var(${s.color})`,
+            }),
+          );
+          continue;
+        }
+        const d = seg
+          .map(
+            (p, i) =>
+              `${i === 0 ? "M" : "L"}${plotX(p.x).toFixed(1)},${plotY(p.y as number).toFixed(1)}`,
+          )
+          .join("");
+        const path = el("path", {
+          d,
+          fill: "none",
+          stroke: `var(${s.color})`,
+          "stroke-width": 2,
+          "stroke-linejoin": "round",
+          "stroke-linecap": "round",
+        });
+        if (s.dashed) path.setAttribute("stroke-dasharray", "5 4");
+        svg.appendChild(path);
+      }
+    }
+
+    // Markers (with surface ring) + selective labels.
+    for (const m of panel.markers ?? []) {
+      if (m.x < x0 || m.x > x1) continue;
+      const cx = plotX(m.x);
+      const cy = plotY(m.y);
+      svg.appendChild(el("circle", { cx, cy, r: 6, class: "pt-marker-ring" }));
+      svg.appendChild(el("circle", { cx, cy, r: 4, fill: `var(${m.color})` }));
+      if (m.label) {
+        const above = cy > MARGIN.top + 26;
+        // Keep labels inside the plot area near the edges.
+        const lx = Math.min(
+          width - MARGIN.right - 24,
+          Math.max(MARGIN.left + 24, cx),
+        );
+        const label = el("text", {
+          x: lx,
+          y: above ? cy - 10 : cy + 16,
+          class: "pt-marker-label",
+          "text-anchor": "middle",
+        });
+        label.textContent = m.label;
+        svg.appendChild(label);
+        if (m.sub) {
+          const sub = el("text", {
+            x: lx,
+            y: above ? cy - 10 + 11 : cy + 16 + 11,
+            class: "pt-marker-sub",
+            "text-anchor": "middle",
+          });
+          // Sub-label sits between the main label and the dot when above.
+          if (above) {
+            label.setAttribute("y", String(cy - 21));
+            sub.setAttribute("y", String(cy - 10));
+          }
+          sub.textContent = m.sub;
+          svg.appendChild(sub);
+        }
+      }
+    }
+
+    const hoverLayer = el("g");
+    svg.appendChild(hoverLayer);
+    this.layouts.push({ panel, svg, plotX, plotY, hoverLayer, width, height });
+  }
+
+  private onPointer(e: PointerEvent): void {
+    if (this.allX.length === 0) return;
+    const first = this.layouts[0];
+    if (!first) return;
+    const rect = (
+      e.target instanceof Element
+        ? (e.target.closest(".pt-panel svg") ?? first.svg)
+        : first.svg
+    ).getBoundingClientRect();
+    const [x0, x1] = this.opts.xDomain;
+    const frac =
+      (e.clientX - rect.left - MARGIN.left) /
+      (rect.width - MARGIN.left - MARGIN.right);
+    const targetX = x0 + Math.min(1, Math.max(0, frac)) * (x1 - x0);
+    const snapped = nearest(this.allX, targetX);
+    this.drawHover(snapped, e);
+  }
+
+  private drawHover(x: number, e: PointerEvent): void {
+    const rows: Array<{ label: string; value: string; color: string }> = [];
+    for (const layout of this.layouts) {
+      layout.hoverLayer.textContent = "";
+      const { panel, plotX, plotY } = layout;
+      const px = plotX(x);
+      layout.hoverLayer.appendChild(
+        el("line", {
+          x1: px,
+          x2: px,
+          y1: MARGIN.top,
+          y2: layout.height - MARGIN.bottom,
+          class: "pt-crosshair",
+        }),
+      );
+      for (const s of panel.series) {
+        const pt = s.points.find((p) => p.x === x);
+        if (!pt || pt.y === null) continue;
+        layout.hoverLayer.appendChild(
+          el("circle", {
+            cx: px,
+            cy: plotY(pt.y),
+            r: 5,
+            class: "pt-marker-ring",
+          }),
+        );
+        layout.hoverLayer.appendChild(
+          el("circle", {
+            cx: px,
+            cy: plotY(pt.y),
+            r: 3.5,
+            fill: `var(${s.color})`,
+          }),
+        );
+        rows.push({
+          label: s.label + (panel.unit ? ` (${panel.unit})` : ""),
+          value: s.fmt ? s.fmt(pt.y) : formatTick(pt.y),
+          color: s.color,
+        });
+      }
+    }
+
+    // Tooltip.
+    this.tooltip.textContent = "";
+    const head = div("pt-tooltip-head");
+    head.textContent = this.opts.fmtXLong(x);
+    this.tooltip.appendChild(head);
+    for (const row of rows) {
+      const line = div("pt-tooltip-row");
+      const key = document.createElement("span");
+      key.className = "pt-legend-key";
+      key.style.background = `var(${row.color})`;
+      line.appendChild(key);
+      const value = document.createElement("strong");
+      value.textContent = row.value;
+      line.appendChild(value);
+      const label = document.createElement("span");
+      label.className = "pt-tooltip-label";
+      label.textContent = row.label;
+      line.appendChild(label);
+      this.tooltip.appendChild(line);
+    }
+    this.tooltip.style.display = rows.length > 0 ? "block" : "none";
+    const rootRect = this.root.getBoundingClientRect();
+    const tipWidth = this.tooltip.offsetWidth || 140;
+    let left = e.clientX - rootRect.left + 14;
+    if (left + tipWidth > rootRect.width - 8) {
+      left = e.clientX - rootRect.left - tipWidth - 14;
+    }
+    this.tooltip.style.left = `${Math.max(0, left)}px`;
+    this.tooltip.style.top = `${e.clientY - rootRect.top + 12}px`;
+  }
+
+  private clearHover(): void {
+    for (const layout of this.layouts) layout.hoverLayer.textContent = "";
+    this.tooltip.style.display = "none";
+  }
+}
+
+/** Split a point list into contiguous non-null segments (gaps stay gaps). */
+function splitSegments(points: Pt[]): Array<Array<{ x: number; y: number }>> {
+  const segments: Array<Array<{ x: number; y: number }>> = [];
+  let current: Array<{ x: number; y: number }> = [];
+  for (const p of points) {
+    if (p.y === null) {
+      if (current.length > 0) segments.push(current);
+      current = [];
+    } else {
+      current.push({ x: p.x, y: p.y });
+    }
+  }
+  if (current.length > 0) segments.push(current);
+  return segments;
+}
+
+function nearest(sorted: number[], target: number): number {
+  let lo = 0;
+  let hi = sorted.length - 1;
+  while (hi - lo > 1) {
+    const mid = (lo + hi) >> 1;
+    if (sorted[mid] < target) lo = mid;
+    else hi = mid;
+  }
+  return Math.abs(sorted[lo] - target) <= Math.abs(sorted[hi] - target)
+    ? sorted[lo]
+    : sorted[hi];
+}
+
+export function formatTick(v: number): string {
+  const abs = Math.abs(v);
+  if (abs >= 1000)
+    return v.toLocaleString("en-US", { maximumFractionDigits: 0 });
+  if (abs >= 100) return v.toFixed(0);
+  if (abs >= 10) return v.toFixed(1).replace(/\.0$/, "");
+  return v.toFixed(2).replace(/0$/, "").replace(/\.$/, "");
+}

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -1,0 +1,835 @@
+/**
+ * Perigee Charts — the iframe side of the MCP app.
+ *
+ * One template serves every visualization-bearing tool: the host delivers the
+ * tool's CallToolResult via ui/notifications/tool-result, and this module
+ * dispatches on `structuredContent.viz.kind`:
+ *   tide_curve       noaa_get_tide_predictions
+ *   solunar          astro_get_solunar_forecast
+ *   buoy_obs         ndbc_get_buoy_observations
+ *   marine_forecast  openmeteo_get_marine_forecast
+ *
+ * Time handling: series that arrive in station-local time (tides) or a
+ * chosen display zone (solunar) are mapped to "display epochs" — the wall
+ * time re-labeled as UTC — so all axis math runs on plain numbers and labels
+ * are formatted with UTC accessors. Truly-UTC series (buoy, marine) stay UTC.
+ */
+
+import { App } from "@modelcontextprotocol/ext-apps";
+import { Chart, Panel, Pt, formatTick } from "./chart.js";
+
+interface VizMeta {
+  kind: string;
+  timezone?: string;
+}
+
+type Structured = Record<string, unknown> & { viz?: VizMeta };
+
+const rootEl = (): HTMLElement => {
+  const node = document.getElementById("app");
+  if (!node) throw new Error("missing #app");
+  return node;
+};
+
+// ---------------------------------------------------------------------------
+// Time helpers
+// ---------------------------------------------------------------------------
+
+const MINUTE = 60_000;
+const HOUR = 3_600_000;
+
+/** Offset of an IANA zone from UTC at `date`, in ms. */
+function tzOffsetMs(date: Date, timeZone: string): number {
+  try {
+    const dtf = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      hour12: false,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    });
+    const parts: Record<string, string> = {};
+    for (const p of dtf.formatToParts(date)) parts[p.type] = p.value;
+    const asUtc = Date.UTC(
+      Number(parts.year),
+      Number(parts.month) - 1,
+      Number(parts.day),
+      Number(parts.hour) % 24,
+      Number(parts.minute),
+      Number(parts.second),
+    );
+    return asUtc - date.getTime();
+  } catch {
+    return 0;
+  }
+}
+
+function fmtHm(x: number): string {
+  const d = new Date(x);
+  return `${String(d.getUTCHours()).padStart(2, "0")}:${String(d.getUTCMinutes()).padStart(2, "0")}`;
+}
+
+const MONTHS = "Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec".split(" ");
+
+function fmtDay(x: number): string {
+  const d = new Date(x);
+  return `${MONTHS[d.getUTCMonth()]} ${d.getUTCDate()}`;
+}
+
+function makeFmtX(domain: [number, number]): (x: number) => string {
+  return (x) => (domain[1] - domain[0] > 36 * HOUR ? fmtDay(x) : fmtHm(x));
+}
+
+function fmtXLong(x: number): string {
+  return `${fmtDay(x)} ${fmtHm(x)}`;
+}
+
+// ---------------------------------------------------------------------------
+// DOM helpers
+// ---------------------------------------------------------------------------
+
+function div(className: string, text?: string): HTMLDivElement {
+  const node = document.createElement("div");
+  node.className = className;
+  if (text !== undefined) node.textContent = text;
+  return node;
+}
+
+function header(title: string, subtitle?: string): HTMLElement {
+  const head = div("pt-header");
+  head.appendChild(div("pt-title", title));
+  if (subtitle) head.appendChild(div("pt-subtitle", subtitle));
+  return head;
+}
+
+interface Tile {
+  label: string;
+  value: string;
+  delta?: { text: string; dir: "up" | "down" | "flat" };
+}
+
+function tileRow(tiles: Tile[]): HTMLElement {
+  const row = div("pt-tiles");
+  for (const t of tiles) {
+    const tile = div("pt-tile");
+    tile.appendChild(div("pt-tile-label", t.label));
+    tile.appendChild(div("pt-tile-value", t.value));
+    if (t.delta) {
+      const delta = div(
+        `pt-tile-delta pt-delta-${t.delta.dir}`,
+        `${t.delta.dir === "up" ? "▲" : t.delta.dir === "down" ? "▼" : "◆"} ${t.delta.text}`,
+      );
+      tile.appendChild(delta);
+    }
+    row.appendChild(tile);
+  }
+  return row;
+}
+
+/** Filter-chip row; returns the container. `onPick` re-renders content. */
+function chipRow<T>(
+  options: Array<{ label: string; value: T }>,
+  initial: number,
+  onPick: (value: T) => void,
+): HTMLElement {
+  const row = div("pt-chips");
+  const buttons: HTMLButtonElement[] = [];
+  options.forEach((opt, i) => {
+    const btn = document.createElement("button");
+    btn.className = "pt-chip";
+    btn.type = "button";
+    btn.textContent = opt.label;
+    if (i === initial) btn.classList.add("pt-chip-active");
+    btn.addEventListener("click", () => {
+      buttons.forEach((b) => b.classList.remove("pt-chip-active"));
+      btn.classList.add("pt-chip-active");
+      onPick(opt.value);
+    });
+    buttons.push(btn);
+    row.appendChild(btn);
+  });
+  return row;
+}
+
+function noteEl(text: string): HTMLElement {
+  return div("pt-note", text);
+}
+
+function pickLatest<T>(
+  rows: T[],
+  get: (row: T) => number | null,
+): number | null {
+  for (const row of rows) {
+    const v = get(row);
+    if (v !== null && v !== undefined) return v;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Renderers
+// ---------------------------------------------------------------------------
+
+interface TidePrediction {
+  t: string;
+  v: string | number;
+  type?: string;
+  ty?: string;
+}
+
+/** Station-local "YYYY-MM-DD HH:mm[:ss]" → display epoch (wall time as UTC). */
+function parseLocal(t: string): number {
+  const iso = t.replace(" ", "T");
+  return Date.parse(iso.length === 16 ? `${iso}:00Z` : `${iso}Z`);
+}
+
+function renderTide(container: HTMLElement, s: Structured): void {
+  const predictions = (s.predictions as TidePrediction[]) ?? [];
+  const isHilo = s.interval === "hilo";
+  const events = predictions
+    .map((p) => ({
+      x: parseLocal(p.t),
+      y: Number(p.v),
+      type: (p.type ?? p.ty ?? "").trim().toUpperCase(),
+    }))
+    .filter((p) => Number.isFinite(p.x) && Number.isFinite(p.y))
+    .sort((a, b) => a.x - b.x);
+  if (events.length === 0) {
+    container.appendChild(noteEl("No predictions to chart."));
+    return;
+  }
+
+  // hilo mode: reconstruct the curve with cosine interpolation between
+  // consecutive extremes (the standard rendering of tide tables).
+  let curve: Pt[];
+  if (isHilo && events.length >= 2) {
+    curve = [];
+    for (let i = 0; i < events.length - 1; i++) {
+      const a = events[i];
+      const b = events[i + 1];
+      const steps = Math.max(2, Math.round((b.x - a.x) / (10 * MINUTE)));
+      for (let k = 0; k < steps; k++) {
+        const f = k / steps;
+        curve.push({
+          x: a.x + (b.x - a.x) * f,
+          y: a.y + ((b.y - a.y) * (1 - Math.cos(Math.PI * f))) / 2,
+        });
+      }
+    }
+    curve.push({
+      x: events[events.length - 1].x,
+      y: events[events.length - 1].y,
+    });
+  } else {
+    curve = events.map((e) => ({ x: e.x, y: e.y }));
+  }
+
+  const unitsLabel = String(s.units_label ?? "");
+  const stationName = s.station_name ? ` — ${s.station_name}` : "";
+  container.appendChild(
+    header(
+      `Tide Predictions · Station ${String(s.station ?? "")}${stationName}`,
+      `${unitsLabel} · ${String(s.time_zone ?? "")} · astronomical predictions only (no weather effects)`,
+    ),
+  );
+
+  const fullDomain: [number, number] = [curve[0].x, curve[curve.length - 1].x];
+  const spanHours = (fullDomain[1] - fullDomain[0]) / HOUR;
+  const chartHost = div("pt-chart-host");
+
+  const draw = (domain: [number, number]) => {
+    chartHost.textContent = "";
+    new Chart(chartHost, {
+      xDomain: domain,
+      fmtX: makeFmtX(domain),
+      fmtXLong,
+      now: s.time_zone === "gmt" ? Date.now() : undefined,
+      panels: [
+        {
+          unit: unitsLabel,
+          series: [
+            {
+              label: "Predicted height",
+              color: "--s1",
+              points: curve,
+              area: true,
+            },
+          ],
+          markers: isHilo
+            ? events
+                .filter((e) => e.x >= domain[0] && e.x <= domain[1])
+                .map((e) => ({
+                  x: e.x,
+                  y: e.y,
+                  color: e.type.startsWith("H") ? "--s1" : "--s2",
+                  label: `${e.type.startsWith("H") ? "High" : "Low"} ${formatTick(e.y)}`,
+                  sub: fmtHm(e.x),
+                }))
+            : undefined,
+          height: 240,
+          includeZero: true,
+        },
+      ],
+    });
+  };
+
+  if (spanHours > 30) {
+    const allPresets: Array<{ label: string; value: [number, number] }> = [
+      { label: "24h", value: [fullDomain[0], fullDomain[0] + 24 * HOUR] },
+      { label: "3d", value: [fullDomain[0], fullDomain[0] + 72 * HOUR] },
+      { label: "All", value: fullDomain },
+    ];
+    const presets = allPresets.filter(
+      (p) => p.value[1] <= fullDomain[1] + 12 * HOUR,
+    );
+    container.appendChild(
+      chipRow(presets, presets.length - 1, (domain) => draw(domain)),
+    );
+  }
+  container.appendChild(chartHost);
+  draw(fullDomain);
+}
+
+// --- Solunar ----------------------------------------------------------------
+
+interface SolunarPeriodJson {
+  kind: "major" | "minor";
+  event: string;
+  start: string;
+  peak: string;
+  end: string;
+  overlaps_twilight: boolean;
+}
+
+interface SolunarDayJson {
+  date: string;
+  time_basis: string;
+  moon_phase: string;
+  moon_illumination: number;
+  sunrise: string | null;
+  sunset: string | null;
+  moonrise: string | null;
+  moonset: string | null;
+  rating: number;
+  rating_label: string;
+  periods: SolunarPeriodJson[];
+  hourly_activity: Array<{ time: string; activity: number }>;
+}
+
+function renderSolunar(container: HTMLElement, s: Structured): void {
+  const days = (s.days as SolunarDayJson[]) ?? [];
+  if (days.length === 0) {
+    container.appendChild(noteEl("No solunar data to chart."));
+    return;
+  }
+  const timezone = s.viz?.timezone;
+  const basis = days[0].time_basis;
+  // Display epoch: wall time in the display zone, re-labeled as UTC.
+  const fixedOffsetMatch = basis.match(/^UTC([+-]\d+)/);
+  const toDisplay = (iso: string): number => {
+    const t = Date.parse(iso);
+    if (timezone) return t + tzOffsetMs(new Date(t), timezone);
+    if (fixedOffsetMatch) return t + Number(fixedOffsetMatch[1]) * HOUR;
+    return t;
+  };
+  const nowDisplay = () =>
+    timezone
+      ? Date.now() + tzOffsetMs(new Date(), timezone)
+      : fixedOffsetMatch
+        ? Date.now() + Number(fixedOffsetMatch[1]) * HOUR
+        : Date.now();
+
+  container.appendChild(
+    header(
+      "Solunar Fishing Forecast",
+      `${String(s.count ?? days.length)} day(s) · times in ${timezone ?? basis} · heuristic — weigh against tide, wind, and pressure`,
+    ),
+  );
+
+  const body = div("pt-solunar-body");
+
+  const drawDay = (day: SolunarDayJson) => {
+    body.textContent = "";
+    body.appendChild(
+      tileRow([
+        { label: "Day rating", value: `${day.rating}/100` },
+        { label: "Outlook", value: day.rating_label },
+        {
+          label: "Moon",
+          value: `${day.moon_phase}`,
+        },
+        {
+          label: "Illumination",
+          value: `${Math.round(day.moon_illumination * 100)}%`,
+        },
+      ]),
+    );
+
+    const activity: Pt[] = day.hourly_activity.map((a) => ({
+      x: toDisplay(a.time),
+      y: a.activity,
+    }));
+    if (activity.length === 0) return;
+    const domain: [number, number] = [
+      activity[0].x,
+      activity[activity.length - 1].x,
+    ];
+
+    const markers = [];
+    if (day.sunrise)
+      markers.push({
+        x: toDisplay(day.sunrise),
+        y: 6,
+        color: "--s3",
+        label: "Sunrise",
+        sub: fmtHm(toDisplay(day.sunrise)),
+      });
+    if (day.sunset)
+      markers.push({
+        x: toDisplay(day.sunset),
+        y: 6,
+        color: "--s3",
+        label: "Sunset",
+        sub: fmtHm(toDisplay(day.sunset)),
+      });
+
+    const chartHost = div("pt-chart-host");
+    body.appendChild(chartHost);
+    new Chart(chartHost, {
+      xDomain: domain,
+      fmtX: fmtHm,
+      fmtXLong,
+      now: nowDisplay(),
+      panels: [
+        {
+          title: `Predicted feeding activity — ${day.date}`,
+          unit: "0-100",
+          series: [
+            {
+              label: "Activity",
+              color: "--s1",
+              points: activity,
+              area: true,
+              fmt: (v) => String(Math.round(v)),
+            },
+          ],
+          bands: day.periods.map((p) => ({
+            x0: toDisplay(p.start),
+            x1: toDisplay(p.end),
+            color: p.kind === "major" ? "--s1" : "--s2",
+          })),
+          markers,
+          yDomain: [0, 108],
+          height: 200,
+        },
+      ],
+    });
+
+    const legend = div("pt-band-legend");
+    for (const [color, label] of [
+      ["--s1", "major period (moon overhead/underfoot)"],
+      ["--s2", "minor period (moonrise/moonset)"],
+    ] as const) {
+      const item = div("pt-legend-item");
+      const key = document.createElement("span");
+      key.className = "pt-legend-key pt-legend-band";
+      key.style.background = `var(${color})`;
+      item.appendChild(key);
+      item.appendChild(document.createTextNode(label));
+      legend.appendChild(item);
+    }
+    body.appendChild(legend);
+
+    const list = div("pt-period-list");
+    for (const p of day.periods) {
+      const row = div("pt-period-row");
+      row.appendChild(
+        div(
+          `pt-period-kind pt-period-${p.kind}`,
+          p.kind === "major" ? "MAJOR" : "minor",
+        ),
+      );
+      row.appendChild(
+        div(
+          "pt-period-time",
+          `${fmtHm(toDisplay(p.start))} – ${fmtHm(toDisplay(p.end))}`,
+        ),
+      );
+      row.appendChild(
+        div(
+          "pt-period-event",
+          p.event.replace(/_/g, " ") +
+            (p.overlaps_twilight ? " · overlaps dawn/dusk ✳" : ""),
+        ),
+      );
+      list.appendChild(row);
+    }
+    body.appendChild(list);
+  };
+
+  if (days.length > 1) {
+    container.appendChild(
+      chipRow(
+        days.map((d) => ({ label: d.date.slice(5), value: d })),
+        0,
+        drawDay,
+      ),
+    );
+  }
+  container.appendChild(body);
+  drawDay(days[0]);
+}
+
+// --- Buoy observations -------------------------------------------------------
+
+interface BuoyObsJson {
+  time: string;
+  wind_dir_deg: number | null;
+  wind_speed: number | null;
+  wind_gust: number | null;
+  wave_height: number | null;
+  dominant_period_s: number | null;
+  pressure_mb: number | null;
+  pressure_tendency_mb: number | null;
+  air_temp: number | null;
+  water_temp: number | null;
+}
+
+function renderBuoy(container: HTMLElement, s: Structured): void {
+  const obs = ((s.observations as BuoyObsJson[]) ?? []).slice().reverse(); // newest-first → chronological
+  if (obs.length === 0) {
+    container.appendChild(noteEl("No observations to chart."));
+    return;
+  }
+  const labels = (s.unit_labels ?? {}) as Record<string, string>;
+  const station = s.station as { name?: string } | undefined;
+  container.appendChild(
+    header(
+      `Buoy ${String(s.station_id ?? "")}${station?.name ? ` — ${station.name}` : ""}`,
+      `NDBC realtime observations · times UTC`,
+    ),
+  );
+
+  const latest = obs[obs.length - 1];
+  const newestFirst = [...obs].reverse();
+  const tendency = pickLatest(newestFirst, (o) => o.pressure_tendency_mb);
+  container.appendChild(
+    tileRow([
+      {
+        label: `Wind (${labels.wind ?? ""})`,
+        value: `${pickLatest(newestFirst, (o) => o.wind_speed) ?? "—"}`,
+      },
+      {
+        label: `Waves (${labels.waves ?? ""})`,
+        value: `${pickLatest(newestFirst, (o) => o.wave_height) ?? "—"}`,
+      },
+      {
+        label: `Water (${labels.temperature ?? ""})`,
+        value: `${pickLatest(newestFirst, (o) => o.water_temp) ?? "—"}`,
+      },
+      {
+        label: "Pressure (mb)",
+        value: `${pickLatest(newestFirst, (o) => o.pressure_mb) ?? "—"}`,
+        delta:
+          tendency === null
+            ? undefined
+            : {
+                text: `${tendency > 0 ? "+" : ""}${tendency} mb/3h`,
+                dir: tendency > 0.5 ? "up" : tendency < -0.5 ? "down" : "flat",
+              },
+      },
+    ]),
+  );
+
+  const toPoints = (get: (o: BuoyObsJson) => number | null): Pt[] =>
+    obs.map((o) => ({ x: Date.parse(o.time), y: get(o) }));
+
+  const fullDomain: [number, number] = [
+    Date.parse(obs[0].time),
+    Date.parse(latest.time),
+  ];
+
+  const chartHost = div("pt-chart-host");
+  const draw = (domain: [number, number]) => {
+    chartHost.textContent = "";
+    const panels: Panel[] = [];
+    const windSpeed = toPoints((o) => o.wind_speed);
+    const windGust = toPoints((o) => o.wind_gust);
+    if (windSpeed.some((p) => p.y !== null)) {
+      panels.push({
+        title: "Wind",
+        unit: labels.wind,
+        series: [
+          { label: "Speed", color: "--s1", points: windSpeed, area: true },
+          { label: "Gust", color: "--s2", points: windGust, dashed: true },
+        ],
+        includeZero: true,
+      });
+    }
+    const waves = toPoints((o) => o.wave_height);
+    if (waves.some((p) => p.y !== null)) {
+      panels.push({
+        title: "Significant wave height",
+        unit: labels.waves,
+        series: [{ label: "Waves", color: "--s1", points: waves, area: true }],
+        includeZero: true,
+      });
+    }
+    const pressure = toPoints((o) => o.pressure_mb);
+    if (pressure.some((p) => p.y !== null)) {
+      panels.push({
+        title: "Sea-level pressure",
+        unit: "mb",
+        series: [{ label: "Pressure", color: "--s5", points: pressure }],
+      });
+    }
+    const water = toPoints((o) => o.water_temp);
+    const air = toPoints((o) => o.air_temp);
+    if (water.some((p) => p.y !== null) || air.some((p) => p.y !== null)) {
+      panels.push({
+        title: "Temperature",
+        unit: labels.temperature,
+        series: [
+          { label: "Water", color: "--s1", points: water },
+          { label: "Air", color: "--s6", points: air },
+        ],
+      });
+    }
+    if (panels.length === 0) {
+      chartHost.appendChild(
+        noteEl("This station reports no chartable sensors in this window."),
+      );
+      return;
+    }
+    new Chart(chartHost, {
+      xDomain: domain,
+      fmtX: makeFmtX(domain),
+      fmtXLong,
+      now: Date.now(),
+      panels,
+    });
+  };
+
+  const spanHours = (fullDomain[1] - fullDomain[0]) / HOUR;
+  if (spanHours > 30) {
+    const allPresets: Array<{ label: string; value: [number, number] }> = [
+      { label: "24h", value: [fullDomain[1] - 24 * HOUR, fullDomain[1]] },
+      { label: "3d", value: [fullDomain[1] - 72 * HOUR, fullDomain[1]] },
+      { label: "All", value: fullDomain },
+    ];
+    const presets = allPresets.filter(
+      (p) => p.value[0] >= fullDomain[0] - 12 * HOUR,
+    );
+    container.appendChild(chipRow(presets, 0, draw));
+    container.appendChild(chartHost);
+    draw(presets[0].value);
+  } else {
+    container.appendChild(chartHost);
+    draw(fullDomain);
+  }
+}
+
+// --- Marine model forecast ----------------------------------------------------
+
+interface MarineHourJson {
+  time: string;
+  wave_height: number | null;
+  wave_period_s: number | null;
+  wind_wave_height: number | null;
+  swell_height: number | null;
+  swell_period_s: number | null;
+  sea_surface_temp: number | null;
+  current_speed: number | null;
+}
+
+function renderMarine(container: HTMLElement, s: Structured): void {
+  const hours = (s.hourly as MarineHourJson[]) ?? [];
+  if (hours.length === 0) {
+    container.appendChild(noteEl("No forecast data to chart."));
+    return;
+  }
+  const labels = (s.unit_labels ?? {}) as Record<string, string>;
+  container.appendChild(
+    header(
+      `Marine Model Forecast · (${String(s.latitude)}, ${String(s.longitude)})`,
+      "Open-Meteo wave-model blend · forecast, not observations · times UTC",
+    ),
+  );
+
+  const toPoints = (get: (h: MarineHourJson) => number | null): Pt[] =>
+    hours.map((h) => ({ x: Date.parse(h.time), y: get(h) }));
+  const fullDomain: [number, number] = [
+    Date.parse(hours[0].time),
+    Date.parse(hours[hours.length - 1].time),
+  ];
+
+  const chartHost = div("pt-chart-host");
+  const draw = (domain: [number, number]) => {
+    chartHost.textContent = "";
+    const panels: Panel[] = [
+      {
+        title: "Wave height",
+        unit: labels.waves,
+        series: [
+          {
+            label: "Combined",
+            color: "--s1",
+            points: toPoints((h) => h.wave_height),
+            area: true,
+          },
+          {
+            label: "Swell",
+            color: "--s2",
+            points: toPoints((h) => h.swell_height),
+          },
+          {
+            label: "Wind wave",
+            color: "--s3",
+            points: toPoints((h) => h.wind_wave_height),
+          },
+        ],
+        includeZero: true,
+      },
+      {
+        title: "Period",
+        unit: "s",
+        series: [
+          {
+            label: "Combined",
+            color: "--s1",
+            points: toPoints((h) => h.wave_period_s),
+          },
+          {
+            label: "Swell",
+            color: "--s2",
+            points: toPoints((h) => h.swell_period_s),
+          },
+        ],
+        includeZero: true,
+      },
+    ];
+    const sst = toPoints((h) => h.sea_surface_temp);
+    if (sst.some((p) => p.y !== null)) {
+      panels.push({
+        title: "Sea surface temperature",
+        unit: labels.temperature,
+        series: [{ label: "SST", color: "--s6", points: sst }],
+      });
+    }
+    const current = toPoints((h) => h.current_speed);
+    if (current.some((p) => p.y !== null)) {
+      panels.push({
+        title: "Surface current",
+        unit: labels.currents,
+        series: [
+          { label: "Current", color: "--s5", points: current, area: true },
+        ],
+        includeZero: true,
+      });
+    }
+    new Chart(chartHost, {
+      xDomain: domain,
+      fmtX: makeFmtX(domain),
+      fmtXLong,
+      now: Date.now(),
+      panels,
+    });
+  };
+
+  const spanHours = (fullDomain[1] - fullDomain[0]) / HOUR;
+  if (spanHours > 30) {
+    const allPresets: Array<{ label: string; value: [number, number] }> = [
+      { label: "24h", value: [fullDomain[0], fullDomain[0] + 24 * HOUR] },
+      { label: "3d", value: [fullDomain[0], fullDomain[0] + 72 * HOUR] },
+      { label: "All", value: fullDomain },
+    ];
+    const presets = allPresets.filter(
+      (p) => p.value[1] <= fullDomain[1] + 12 * HOUR,
+    );
+    container.appendChild(chipRow(presets, presets.length - 1, draw));
+    container.appendChild(chartHost);
+    draw(fullDomain);
+  } else {
+    container.appendChild(chartHost);
+    draw(fullDomain);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// App wiring
+// ---------------------------------------------------------------------------
+
+function renderResult(result: {
+  structuredContent?: unknown;
+  content?: Array<{ type: string; text?: string }>;
+  isError?: boolean;
+}): void {
+  const container = rootEl();
+  container.textContent = "";
+  if (result.isError) {
+    const text =
+      result.content?.find((c) => c.type === "text")?.text ?? "Tool error.";
+    container.appendChild(noteEl(text));
+    return;
+  }
+  const s = (result.structuredContent ?? {}) as Structured;
+  try {
+    switch (s.viz?.kind) {
+      case "tide_curve":
+        renderTide(container, s);
+        break;
+      case "solunar":
+        renderSolunar(container, s);
+        break;
+      case "buoy_obs":
+        renderBuoy(container, s);
+        break;
+      case "marine_forecast":
+        renderMarine(container, s);
+        break;
+      default:
+        container.appendChild(
+          noteEl("No chart is defined for this tool result."),
+        );
+    }
+  } catch (error) {
+    container.appendChild(
+      noteEl(
+        `Chart rendering failed: ${error instanceof Error ? error.message : String(error)}`,
+      ),
+    );
+  }
+}
+
+function applyTheme(theme: unknown): void {
+  if (theme === "dark" || theme === "light") {
+    document.documentElement.dataset.theme = theme;
+  }
+}
+
+async function main(): Promise<void> {
+  const app = new App(
+    { name: "Perigee Charts", version: "1.0.0" },
+    {},
+    { autoResize: true },
+  );
+  app.ontoolresult = (result) => renderResult(result);
+  app.onhostcontextchanged = (ctx) =>
+    applyTheme((ctx as { theme?: string })?.theme);
+  await app.connect();
+  const ctx = (
+    app as unknown as { getHostContext?: () => { theme?: string } | undefined }
+  ).getHostContext?.();
+  applyTheme(ctx?.theme);
+}
+
+main().catch((error) => {
+  rootEl().appendChild(
+    noteEl(
+      `Failed to connect to host: ${error instanceof Error ? error.message : String(error)}`,
+    ),
+  );
+});

--- a/ui/src/shell.html
+++ b/ui/src/shell.html
@@ -1,0 +1,364 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Perigee Charts</title>
+    <style>
+      /* Palette roles (validated reference palette; light is the default,
+         dark comes from prefers-color-scheme with an explicit host override
+         via [data-theme] winning in both directions). */
+      :root {
+        --surface: #fcfcfb;
+        --page: #f9f9f7;
+        --ink: #0b0b0b;
+        --ink-2: #52514e;
+        --muted: #898781;
+        --grid: #e1e0d9;
+        --axis: #c3c2b7;
+        --border: rgba(11, 11, 11, 0.1);
+        --s1: #2a78d6; /* blue */
+        --s2: #1baf7a; /* aqua */
+        --s3: #eda100; /* yellow */
+        --s4: #008300; /* green */
+        --s5: #4a3aa7; /* violet */
+        --s6: #e34948; /* red */
+        --up: #006300;
+        --down: #d03b3b;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --surface: #1a1a19;
+          --page: #0d0d0d;
+          --ink: #ffffff;
+          --ink-2: #c3c2b7;
+          --muted: #898781;
+          --grid: #2c2c2a;
+          --axis: #383835;
+          --border: rgba(255, 255, 255, 0.1);
+          --s1: #3987e5;
+          --s2: #199e70;
+          --s3: #c98500;
+          --s4: #008300;
+          --s5: #9085e9;
+          --s6: #e66767;
+          --up: #0ca30c;
+          --down: #d03b3b;
+        }
+      }
+      :root[data-theme="light"] {
+        --surface: #fcfcfb;
+        --page: #f9f9f7;
+        --ink: #0b0b0b;
+        --ink-2: #52514e;
+        --muted: #898781;
+        --grid: #e1e0d9;
+        --axis: #c3c2b7;
+        --border: rgba(11, 11, 11, 0.1);
+        --s1: #2a78d6;
+        --s2: #1baf7a;
+        --s3: #eda100;
+        --s4: #008300;
+        --s5: #4a3aa7;
+        --s6: #e34948;
+        --up: #006300;
+        --down: #d03b3b;
+      }
+      :root[data-theme="dark"] {
+        --surface: #1a1a19;
+        --page: #0d0d0d;
+        --ink: #ffffff;
+        --ink-2: #c3c2b7;
+        --muted: #898781;
+        --grid: #2c2c2a;
+        --axis: #383835;
+        --border: rgba(255, 255, 255, 0.1);
+        --s1: #3987e5;
+        --s2: #199e70;
+        --s3: #c98500;
+        --s4: #008300;
+        --s5: #9085e9;
+        --s6: #e66767;
+        --up: #0ca30c;
+        --down: #d03b3b;
+      }
+
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      html,
+      body {
+        background: var(--page);
+        color: var(--ink);
+        font-family:
+          system-ui,
+          -apple-system,
+          "Segoe UI",
+          sans-serif;
+        font-size: 13px;
+        line-height: 1.45;
+      }
+      #app {
+        position: relative;
+        padding: 12px;
+        max-width: 860px;
+        margin: 0 auto;
+      }
+
+      .pt-header {
+        margin-bottom: 10px;
+      }
+      .pt-title {
+        font-size: 15px;
+        font-weight: 600;
+      }
+      .pt-subtitle {
+        color: var(--ink-2);
+        font-size: 12px;
+        margin-top: 2px;
+      }
+
+      .pt-tiles {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin: 10px 0;
+      }
+      .pt-tile {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 8px 12px;
+        min-width: 96px;
+        flex: 1 1 auto;
+      }
+      .pt-tile-label {
+        color: var(--ink-2);
+        font-size: 11px;
+        min-height: 15px;
+      }
+      .pt-tile-value {
+        font-size: 20px;
+        font-weight: 600;
+        margin-top: 2px;
+      }
+      .pt-tile-delta {
+        font-size: 11px;
+        margin-top: 2px;
+        color: var(--ink-2);
+      }
+      .pt-delta-up {
+        color: var(--up);
+      }
+      .pt-delta-down {
+        color: var(--down);
+      }
+
+      .pt-chips {
+        display: flex;
+        gap: 6px;
+        margin: 8px 0;
+        flex-wrap: wrap;
+      }
+      .pt-chip {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 999px;
+        color: var(--ink-2);
+        cursor: pointer;
+        font: inherit;
+        font-size: 12px;
+        padding: 3px 12px;
+      }
+      .pt-chip:hover {
+        border-color: var(--axis);
+      }
+      .pt-chip-active {
+        background: var(--ink);
+        border-color: var(--ink);
+        color: var(--page);
+        font-weight: 600;
+      }
+
+      .pt-panel {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        margin-bottom: 10px;
+        padding: 10px 10px 4px;
+      }
+      .pt-panel-head {
+        align-items: baseline;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        margin-bottom: 4px;
+      }
+      .pt-panel-title {
+        font-size: 12px;
+        font-weight: 600;
+      }
+      .pt-panel-unit {
+        color: var(--muted);
+        font-size: 11px;
+      }
+      .pt-legend {
+        display: flex;
+        gap: 12px;
+        margin-left: auto;
+      }
+      .pt-legend-item {
+        align-items: center;
+        color: var(--ink-2);
+        display: flex;
+        font-size: 11px;
+        gap: 5px;
+      }
+      .pt-legend-key {
+        border-radius: 2px;
+        display: inline-block;
+        height: 3px;
+        width: 14px;
+      }
+      .pt-legend-band {
+        height: 10px;
+        opacity: 0.35;
+      }
+      .pt-band-legend {
+        display: flex;
+        gap: 16px;
+        margin: 2px 2px 8px;
+      }
+
+      .pt-svg {
+        display: block;
+        width: 100%;
+        height: auto;
+      }
+      .pt-grid {
+        stroke: var(--grid);
+        stroke-width: 1;
+      }
+      .pt-axis {
+        stroke: var(--axis);
+        stroke-width: 1;
+      }
+      .pt-tick {
+        fill: var(--muted);
+        font-family: inherit;
+        font-size: 10px;
+        font-variant-numeric: tabular-nums;
+      }
+      .pt-nowline {
+        stroke: var(--muted);
+        stroke-dasharray: 2 3;
+        stroke-width: 1;
+      }
+      .pt-crosshair {
+        stroke: var(--axis);
+        stroke-width: 1;
+      }
+      .pt-marker-ring {
+        fill: var(--surface);
+      }
+      .pt-marker-label {
+        fill: var(--ink-2);
+        font-size: 10px;
+        font-weight: 600;
+      }
+      .pt-marker-sub {
+        fill: var(--muted);
+        font-size: 9px;
+        font-variant-numeric: tabular-nums;
+      }
+
+      .pt-tooltip {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        box-shadow: 0 2px 10px rgba(0, 0, 0, 0.14);
+        font-size: 11px;
+        max-width: 240px;
+        padding: 6px 9px;
+        pointer-events: none;
+        position: absolute;
+        z-index: 10;
+      }
+      .pt-tooltip-head {
+        color: var(--ink-2);
+        font-weight: 600;
+        margin-bottom: 3px;
+        font-variant-numeric: tabular-nums;
+      }
+      .pt-tooltip-row {
+        align-items: center;
+        display: flex;
+        gap: 6px;
+        margin: 2px 0;
+      }
+      .pt-tooltip-row strong {
+        font-variant-numeric: tabular-nums;
+      }
+      .pt-tooltip-label {
+        color: var(--ink-2);
+      }
+
+      .pt-period-list {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        margin-bottom: 10px;
+        overflow: hidden;
+      }
+      .pt-period-row {
+        align-items: baseline;
+        border-top: 1px solid var(--grid);
+        display: flex;
+        gap: 12px;
+        padding: 6px 12px;
+      }
+      .pt-period-row:first-child {
+        border-top: none;
+      }
+      .pt-period-kind {
+        font-size: 10px;
+        font-weight: 700;
+        letter-spacing: 0.04em;
+        width: 46px;
+      }
+      .pt-period-major {
+        color: var(--s1);
+      }
+      .pt-period-minor {
+        color: var(--ink-2);
+      }
+      .pt-period-time {
+        font-variant-numeric: tabular-nums;
+        font-weight: 600;
+      }
+      .pt-period-event {
+        color: var(--ink-2);
+      }
+
+      .pt-note {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        color: var(--ink-2);
+        margin: 8px 0;
+        padding: 10px 12px;
+      }
+      .pt-chart-host {
+        position: relative;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app"><div class="pt-note">Waiting for tool data…</div></div>
+    <script type="module">
+      /*__BUNDLE__*/
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

- Close the data gap against the major fishing apps (Fishbrain, Fishing Points, Buoyweather, BassForecast) with five new tools built on free, keyless sources (25 → 30 tools):
  - `astro_get_solunar_forecast` — solunar bite times computed locally: major periods at lunar transits (found by scanning `SunCalc.getMoonPosition` altitude extrema at 1-minute steps, since suncalc has no transit function), minor periods at moonrise/set, a 0–100 day rating with per-factor breakdown (moon phase, perigee distance, dawn/dusk overlap, period count), and a half-hourly activity curve
  - `ndbc_find_nearest_buoys` / `ndbc_get_buoy_observations` — NOAA NDBC realtime text feeds (`activestations.xml` + `realtime2/{ID}.txt`): offshore waves, water temperature, wind, and the 3-hour pressure tendency (PTDY); columns resolved by header name, `MM` → null, fixed metric units converted at the tool layer
  - `noaa_get_pressure_trend` — barometric trajectory from CO-OPS `air_pressure` classified into angler-meaningful states (falling rapidly → rising rapidly) with 3h/6h/24h deltas and bite interpretation
  - `openmeteo_get_marine_forecast` — hourly wave/swell/SST/surface-current model forecast for any ocean coordinate ("virtual buoy"), up to 10 days, via Open-Meteo Marine (`cell_selection=sea` snaps coastal points to ocean cells)
- Add interactive visualizations via the official MCP Apps extension (SEP-1865): one self-contained template (`ui://perigee/charts.html`, `text/html;profile=mcp-app`) shared by four tools, dispatching on `structuredContent.viz.kind` — tide curve (cosine-reconstructed from hilo events, labeled H/L markers), solunar activity chart with period bands and day tabs, multi-panel buoy dashboard with shared crosshair and stat tiles, and marine forecast panels. Hand-rolled SVG (no CDN — runs in the zero-network Apps sandbox), light/dark themed, with tooltips and time-range chips; built by `scripts/build-ui.mjs` (esbuild bundle inlined into a shell page)
- New `fishing` reference topic, README/CLAUDE.md updates, smoke-live coverage for the new tools (including deliberate-error cases)

## Verification

- [x] `npm run build`
- [x] `npm test` — 53 tests passing, incl. new solunar math, NDBC parsing, unit-conversion, and pressure-classification suites
- [ ] `npm run test:live` — could not run from the dev sandbox (network policy blocks NOAA/NDBC/Open-Meteo egress); new tool calls are in the script and should be exercised from an unrestricted machine before release
- [x] Package metadata checked — description/keywords updated; new runtime dep `@modelcontextprotocol/ext-apps`, dev dep `esbuild`; `dist/ui` ships via the existing `files: ["dist"]`

Additional verification: charts were rendered in a local MCP Apps host harness (postMessage JSON-RPC handshake + `ui/notifications/tool-result`) and screenshot-reviewed in light and dark themes; a stdio JSON-RPC smoke confirmed 30 tools, `_meta.ui.resourceUri` on the four app tools, and the `ui://` resource serving with the correct mimeType.

## MCP Behavior

- Added tools: `astro_get_solunar_forecast`, `ndbc_find_nearest_buoys`, `ndbc_get_buoy_observations`, `noaa_get_pressure_trend`, `openmeteo_get_marine_forecast`
- Added resource: `ui://perigee/charts.html` (MCP Apps template); reference topic `fishing` (also served as `noaa://reference/fishing`)
- Behavior change: `noaa_get_tide_predictions`, `astro_get_solunar_forecast`, `ndbc_get_buoy_observations`, and `openmeteo_get_marine_forecast` now register via `registerAppTool` and carry `_meta.ui.resourceUri`; their `structuredContent` gains a small `viz` discriminator. Markdown/JSON output is unchanged in shape — hosts without Apps support see no difference
- No tools removed or renamed

## Risk And Rollback

- Risk: low for existing consumers — new tools are additive and `_meta.ui` is ignored by non-Apps hosts. Main uncertainties: NDBC/Open-Meteo parsing not yet exercised against the live endpoints from this environment (formats are long-stable and unit-tested against documented fixtures), and the chart template (~325 KB) rides `resources/read` in Apps hosts
- Rollback: revert the commit; no data migrations, no config changes. Removing the `ext-apps` dependency and `src/ui` restores the pre-Apps server wholesale

## Codex Notes

- Related plan issue: none (initiated from a Claude Code session)
- Owner approval source: requested by @RyanCardin15 in the driving session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FUue6r8ekvcUspvNxLmTNH

---
_Generated by [Claude Code](https://claude.ai/code/session_01FUue6r8ekvcUspvNxLmTNH)_